### PR TITLE
docs: improve examples structure to be clearer and easier to follow

### DIFF
--- a/apps/content/content/docs/client/react-query.mdx
+++ b/apps/content/content/docs/client/react-query.mdx
@@ -31,7 +31,7 @@ const client = createORPCClient<typeof router /* or contract router */>(orpcLink
 export const orpc = createORPCReactQueryUtils(client);
 
 // @noErrors
-orpc.getting.
+orpc.getUser.
 //           ^|
 ```
 
@@ -61,7 +61,7 @@ export function useORPC() {
 export function ORPCProvider({ children }: { children: React.ReactNode }) {
   const [client] = React.useState(() => {
     const orpcLink = new ORPCLink({
-      url: 'http://localhost:3000/api',
+      url: 'https://exanple.com/api',
       // fetch: optional override for the default fetch function
       // headers: provide additional headers
     });
@@ -84,7 +84,7 @@ export function ORPCProvider({ children }: { children: React.ReactNode }) {
 // Example usage
 const orpc = useORPC();
 // @noErrors
-orpc.getting.
+orpc.getUser.
 //           ^|
 ```
 
@@ -111,20 +111,20 @@ import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from '@tansta
 import { orpc } from 'examples/react-query'
 
 // Fetch data
-const { data: gettingData } = useQuery(orpc.getting.queryOptions({ input: { name: 'unnoq' } }))
+const { data: gettingData } = useQuery(orpc.getUser.queryOptions({ input: { id: '123' } }))
 
 // Use suspense query
 const { data: postData } = useSuspenseQuery(
-  orpc.post.find.queryOptions({ input: { id: 'example' } }),
+  orpc.posts.getPost.queryOptions({ input: { id: 'example' } }),
 )
 
 // Perform mutations
-const { mutate: postMutate } = useMutation(orpc.post.create.mutationOptions())
+const { mutate: postMutate } = useMutation(orpc.posts.createPost.mutationOptions())
 
 // Invalidate queries
 const queryClient = useQueryClient()
 queryClient.invalidateQueries({ queryKey: orpc.key() }) // Invalidate all queries
-queryClient.invalidateQueries({ queryKey: orpc.post.find.key({ input: { id: 'example' } }) }) // Specific queries
+queryClient.invalidateQueries({ queryKey: orpc.posts.getPost.key({ input: { id: 'example' } }) }) // Specific queries
 ```
 
 > **Note**: This library enhances [TanStack Query](https://tanstack.com/query/latest) by managing query keys and functions for you, providing a seamless developer experience.

--- a/apps/content/content/docs/client/react.mdx
+++ b/apps/content/content/docs/client/react.mdx
@@ -26,7 +26,7 @@ export const { orpc, ORPCContext } = createORPCReact<RouterClient<typeof router 
 export function ORPCProvider({ children }: { children: React.ReactNode }) {
     const [client] = useState(() => {
         const orpcLink = new ORPCLink({
-            url: 'http://localhost:3000/api',
+            url: 'https://example.com/api',
             // fetch: optional override for the default fetch function
             // headers: provide additional headers
         })
@@ -54,13 +54,13 @@ You can create it globally or in a component based on your needs.
 ```tsx twoslash
 import { orpc } from 'examples/react'
 
-const { data: gettingData } = orpc.getting.useQuery({ name: 'unnoq' })
-const { data: postData } = orpc.post.find.useQuery({ id: 'example' })
-const { mutate: postMutate } = orpc.post.create.useMutation()
+const { data: gettingData } = orpc.getUser.useQuery({ id: '123' })
+const { data: postData } = orpc.posts.getPost.useQuery({ id: 'example' })
+const { mutate: postMutate } = orpc.posts.createPost.useMutation()
 
 // @noErrors
-orpc.post.find.
-//             ^|
+orpc.posts.getPost.
+//                 ^|
 
 
 
@@ -131,11 +131,11 @@ import { orpc } from 'examples/react'
 
 const utils = orpc.useUtils()
 utils.invalidate() // invalidate all queries
-const data = await utils.getting.fetchQuery({ name: 'unnoq' })
+const data = await utils.getUser.fetchQuery({ id: '123' })
 
 // @noErrors
-utils.post.find.
-//              ^|
+utils.posts.getPost.
+//                  ^|
 ```
 
 ## Use Queries
@@ -144,8 +144,8 @@ utils.post.find.
 import { orpc } from 'examples/react'
 
 const queries = orpc.useQueries(o => [
-  o.getting({ name: 'unnoq' }), 
-  o.post.find({ id: 'example' })
+  o.getUser({ id: '123' }), 
+  o.posts.getPost({ id: 'example' })
 ])
 ```
 
@@ -156,7 +156,7 @@ import { orpc } from 'examples/react'
 
 const {client, queryClient} = orpc.useContext()
 
-const data = await client.getting({ name: 'unnoq' })
+const data = await client.getUser({ id: '123' })
 ```
 
 ## Others

--- a/apps/content/content/docs/client/vanilla.mdx
+++ b/apps/content/content/docs/client/vanilla.mdx
@@ -27,15 +27,15 @@ const orpcLink = new ORPCLink({
 const client = createORPCClient<typeof router /* or contract router */>(orpcLink)
  
 //  File upload out of the box
-const output = await client.post.create({
+const output = await client.posts.createPost({
   title: 'My Amazing Title',
   description: 'This is a detailed description of my content',
   thumb: (document.getElementById('thumb') as HTMLInputElement).files[0]!,
 })
 
 // @noErrors
-client.post.
-//          ^|
+client.posts.
+//           ^|
 ```
 
 ## Client Context
@@ -75,7 +75,7 @@ const orpcLink = new ORPCLink<ClientContext>({
 
 const client = createORPCClient<typeof router, ClientContext>(orpcLink)
 
-client.getting({ name: 'unnoq' }, { context: { cache: 'force-cache' } })
+client.getUser({ id: '123' }, { context: { cache: 'force-cache' } })
 ```
 
 > **Note**: This works seamlessly with [Vue Query](/docs/client/vue-query) and [React Query](/docs/client/react-query).

--- a/apps/content/content/docs/client/vue-query.mdx
+++ b/apps/content/content/docs/client/vue-query.mdx
@@ -30,7 +30,7 @@ export const client = createORPCClient<typeof router>(orpcLink);
 export const orpc = createORPCVueQueryUtils(client);
 
 // @noErrors
-orpc.getting.
+orpc.getUser.
 //           ^|
 ```
 
@@ -57,15 +57,15 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/vue-query'
 import { orpc } from 'examples/vue-query'
 
 // Fetch data
-const { data: gettingData } = useQuery(orpc.getting.queryOptions({ input: { name: 'unnoq' } }))
+const { data: gettingData } = useQuery(orpc.getUser.queryOptions({ input: { id: '123' } }))
 
 // Perform mutations
-const { mutate: postMutate } = useMutation(orpc.post.create.mutationOptions())
+const { mutate: postMutate } = useMutation(orpc.posts.createPost.mutationOptions())
 
 // Invalidate queries
 const queryClient = useQueryClient()
 queryClient.invalidateQueries({ queryKey: orpc.key() }) // Invalidate all queries
-queryClient.invalidateQueries({ queryKey: orpc.post.find.key({ input: { id: 'example' } }) }) // Specific queries
+queryClient.invalidateQueries({ queryKey: orpc.posts.getPost.key({ input: { id: 'example' } }) }) // Specific queries
 ```
 
 > **Note**: This library enhances [TanStack Query](https://tanstack.com/query/latest) by managing query keys and functions for you, providing a seamless developer experience.

--- a/apps/content/content/docs/contract-first.mdx
+++ b/apps/content/content/docs/contract-first.mdx
@@ -90,16 +90,16 @@ With your contract defined, implement the server logic:
 import { os, ORPCError } from '@orpc/server'
 import { contract } from 'examples/contract'
 
-export const publicRoute = os.contract(contract) // Ensure every implement must be match contract
-export const authRoute = os
+export const pub = os.contract(contract) // Ensure every implement must be match contract
+export const authed = os
   .use((input, context, meta) => {
     /** put auth logic here */
     return meta.next({})
   })
   .contract(contract)
 
-export const router = publicRoute.router({
-  getUser: publicRoute.getUser.handler((input, context, meta) => {
+export const router = pub.router({
+  getUser: pub.getUser.handler((input, context, meta) => {
     return {
       username: 'example',
       avatar: 'example',
@@ -107,7 +107,7 @@ export const router = publicRoute.router({
   }),
 
   posts: {
-    getPost: publicRoute.posts.getPost
+    getPost: pub.posts.getPost
       .handler((input, context, meta) => {
         return {
           id: 'example',
@@ -116,7 +116,7 @@ export const router = publicRoute.router({
         }
       }),
 
-    createPost: authRoute.posts.createPost.handler((input, context, meta) => {
+    createPost: authed.posts.createPost.handler((input, context, meta) => {
       return {
         id: 'example',
         title: input.title,

--- a/apps/content/content/docs/contract-first.mdx
+++ b/apps/content/content/docs/contract-first.mdx
@@ -90,16 +90,16 @@ With your contract defined, implement the server logic:
 import { os, ORPCError } from '@orpc/server'
 import { contract } from 'examples/contract'
 
-export const publicProcedure = os.contract(contract) // Ensure every implement must be match contract
-export const authProcedure = os
+export const publicRoute = os.contract(contract) // Ensure every implement must be match contract
+export const authRoute = os
   .use((input, context, meta) => {
     /** put auth logic here */
     return meta.next({})
   })
   .contract(contract)
 
-export const router = publicProcedure.router({
-  getUser: publicProcedure.getUser.handler((input, context, meta) => {
+export const router = publicRoute.router({
+  getUser: publicRoute.getUser.handler((input, context, meta) => {
     return {
       username: 'example',
       avatar: 'example',
@@ -107,7 +107,7 @@ export const router = publicProcedure.router({
   }),
 
   posts: {
-    getPost: publicProcedure.posts.getPost
+    getPost: publicRoute.posts.getPost
       .handler((input, context, meta) => {
         return {
           id: 'example',
@@ -116,7 +116,7 @@ export const router = publicProcedure.router({
         }
       }),
 
-    createPost: authProcedure.posts.createPost.handler((input, context, meta) => {
+    createPost: authRoute.posts.createPost.handler((input, context, meta) => {
       return {
         id: 'example',
         title: input.title,

--- a/apps/content/content/docs/contract-first.mdx
+++ b/apps/content/content/docs/contract-first.mdx
@@ -28,20 +28,21 @@ import { oz } from '@orpc/zod'
 import { z } from 'zod'
 
 export const contract = oc.router({
-    getting: oc
-    .input(
-      z.object({
-        name: z.string(),
-      }),
-    )
-    .output(
-      z.object({
-        message: z.string(),
-      }),
-    ),
+  getUser: oc
+  .input(
+    z.object({
+      id: z.string(),
+    }),
+  )
+  .output(
+    z.object({
+      username: z.string(),
+      avatar: z.string(),
+    }),
+  ),
 
-  post: oc.prefix('/posts').router({
-    find: oc
+  posts: oc.prefix('/posts').router({
+    getPost: oc
       .route({
         path: '/{id}',
         method: 'GET',
@@ -59,7 +60,7 @@ export const contract = oc.router({
         }),
       ),
 
-    create: oc
+    createPost: oc
       .input(
         z.object({
           title: z.string(),
@@ -89,20 +90,24 @@ With your contract defined, implement the server logic:
 import { os, ORPCError } from '@orpc/server'
 import { contract } from 'examples/contract'
 
-export const pub /** public access */ = os.contract(contract) // Ensure every implement must be match contract
-export const authed /** require authed */ = os
-  .use((input, context, meta) => /** put auth logic here */ meta.next({}))
+export const publicProcedure = os.contract(contract) // Ensure every implement must be match contract
+export const authProcedure = os
+  .use((input, context, meta) => {
+    /** put auth logic here */
+    return meta.next({})
+  })
   .contract(contract)
 
-export const router = pub.router({
-  getting: pub.getting.handler((input, context, meta) => {
+export const router = publicProcedure.router({
+  getUser: publicProcedure.getUser.handler((input, context, meta) => {
     return {
-      message: `Hello, ${input.name}!`,
+      username: 'example',
+      avatar: 'example',
     }
   }),
 
-  post: {
-    find: pub.post.find
+  posts: {
+    getPost: publicProcedure.posts.getPost
       .handler((input, context, meta) => {
         return {
           id: 'example',
@@ -111,7 +116,7 @@ export const router = pub.router({
         }
       }),
 
-    create: authed.post.create.handler((input, context, meta) => {
+    createPost: authProcedure.posts.createPost.handler((input, context, meta) => {
       return {
         id: 'example',
         title: input.title,
@@ -134,7 +139,7 @@ import { ORPCLink } from '@orpc/client/fetch'
 import type { contract } from 'examples/contract'
 
 const orpcLink = new ORPCLink({
-  url: 'http://localhost:3000/prefix',
+  url: 'https://localhost:3000/prefix',
   // fetch: optional override for the default fetch function
   // headers: provide additional headers
 })
@@ -142,15 +147,15 @@ const orpcLink = new ORPCLink({
 const client = createORPCClient<typeof contract /* or server router */>(orpcLink)
  
 //  File upload out of the box
-const output = await client.post.create({
+const output = await client.posts.createPost({
   title: 'My Amazing Title',
   description: 'This is a detailed description of my content',
   thumb: (document.getElementById('thumb') as HTMLInputElement).files[0]!,
 })
 
 // @noErrors
-client.post.
-//          ^|
+client.posts.
+//           ^|
 
 
 

--- a/apps/content/content/docs/index.mdx
+++ b/apps/content/content/docs/index.mdx
@@ -57,28 +57,32 @@ import { z } from 'zod'
 
 export type Context = { user?: { id: string } }
 
-// global pub, authed completely optional
-export const pub /** public access */ = os.context<Context>()
-export const authed /** require authed */ = pub.use((input, context, meta) => /** put auth logic here */ meta.next({}))
+// global publicProcedure, authProcedure completely optional
+export const publicProcedure = os.context<Context>()
+export const authProcedure = publicProcedure.use((input, context, meta) => {
+  /** put auth logic here */
+  return meta.next({})
+})
 
-export const router = pub.router({
-  getting: os
+export const router = publicProcedure.router({
+  getUser: os
     .input(
       z.object({
-        name: z.string(),
+        id: z.string(),
       }),
     )
     .handler(async (input, context, meta) => {
       return {
-        message: `Hello, ${input.name}!`,
+        username: 'example',
+        avatar: 'example',
       }
     }),
 
-  post: {
-    find: pub
+  posts: {
+    getPost: publicProcedure
       .input(
         z.object({
-          id: z.string({}),
+          id: z.string(),
         }),
       )
       .output(
@@ -113,7 +117,7 @@ export const router = pub.router({
         }
       }),
 
-    create: authed
+    createPost: authProcedure
       .input(
         z.object({
           title: z.string(),
@@ -200,15 +204,15 @@ const orpcLink = new ORPCLink({
 const client = createORPCClient<typeof router /* or contract router */>(orpcLink)
  
 //  File upload out of the box
-const output = await client.post.create({
+const output = await client.posts.createPost({
   title: 'My Amazing Title',
   description: 'This is a detailed description of my content',
   thumb: (document.getElementById('thumb') as HTMLInputElement).files[0]!,
 })
 
 // @noErrors
-client.post.
-//          ^|
+client.posts.
+//           ^|
 
 
 

--- a/apps/content/content/docs/index.mdx
+++ b/apps/content/content/docs/index.mdx
@@ -57,14 +57,14 @@ import { z } from 'zod'
 
 export type Context = { user?: { id: string } }
 
-// global publicRoute, authRoute completely optional
-export const publicRoute = os.context<Context>()
-export const authRoute = publicRoute.use((input, context, meta) => {
+// global pub, authed completely optional
+export const pub = os.context<Context>()
+export const authed = pub.use((input, context, meta) => {
   /** put auth logic here */
   return meta.next({})
 })
 
-export const router = publicRoute.router({
+export const router = pub.router({
   getUser: os
     .input(
       z.object({
@@ -79,7 +79,7 @@ export const router = publicRoute.router({
     }),
 
   posts: {
-    getPost: publicRoute
+    getPost: pub
       .input(
         z.object({
           id: z.string(),
@@ -117,7 +117,7 @@ export const router = publicRoute.router({
         }
       }),
 
-    createPost: authRoute
+    createPost: authed
       .input(
         z.object({
           title: z.string(),

--- a/apps/content/content/docs/index.mdx
+++ b/apps/content/content/docs/index.mdx
@@ -57,14 +57,14 @@ import { z } from 'zod'
 
 export type Context = { user?: { id: string } }
 
-// global publicProcedure, authProcedure completely optional
-export const publicProcedure = os.context<Context>()
-export const authProcedure = publicProcedure.use((input, context, meta) => {
+// global publicRoute, authRoute completely optional
+export const publicRoute = os.context<Context>()
+export const authRoute = publicRoute.use((input, context, meta) => {
   /** put auth logic here */
   return meta.next({})
 })
 
-export const router = publicProcedure.router({
+export const router = publicRoute.router({
   getUser: os
     .input(
       z.object({
@@ -79,7 +79,7 @@ export const router = publicProcedure.router({
     }),
 
   posts: {
-    getPost: publicProcedure
+    getPost: publicRoute
       .input(
         z.object({
           id: z.string(),
@@ -117,7 +117,7 @@ export const router = publicProcedure.router({
         }
       }),
 
-    createPost: authProcedure
+    createPost: authRoute
       .input(
         z.object({
           title: z.string(),

--- a/apps/content/content/docs/openapi/generator.mdx
+++ b/apps/content/content/docs/openapi/generator.mdx
@@ -18,14 +18,14 @@ import { z } from 'zod'
 
 export type Context = { user?: { id: string } }
 
-// global publicRoute, authed completely optional
-export const publicRoute = os.context<Context>()
-export const authRoute = publicRoute.use((input, context, meta) => {
+// global pub, authed completely optional
+export const pub = os.context<Context>()
+export const authed = pub.use((input, context, meta) => {
   /** put auth logic here */
   return meta.next({})
 })
 
-export const router = publicRoute.router({
+export const router = pub.router({
   getUser: os
     .input(
       z.object({
@@ -39,8 +39,8 @@ export const router = publicRoute.router({
       }
     }),
 
-  post: publicRoute.prefix('/posts').router({
-    getPost: publicRoute
+  post: pub.prefix('/posts').router({
+    getPost: pub
       .route({
         path: '/{id}', // custom your OpenAPI
         method: 'GET',
@@ -65,7 +65,7 @@ export const router = publicRoute.router({
         }
       }),
 
-    createPost: authRoute
+    createPost: authed
       .input(
         z.object({
           title: z.string(),

--- a/apps/content/content/docs/openapi/generator.mdx
+++ b/apps/content/content/docs/openapi/generator.mdx
@@ -18,14 +18,14 @@ import { z } from 'zod'
 
 export type Context = { user?: { id: string } }
 
-// global publicProcedure, authed completely optional
-export const publicProcedure = os.context<Context>()
-export const authProcedure = publicProcedure.use((input, context, meta) => {
+// global publicRoute, authed completely optional
+export const publicRoute = os.context<Context>()
+export const authRoute = publicRoute.use((input, context, meta) => {
   /** put auth logic here */
   return meta.next({})
 })
 
-export const router = publicProcedure.router({
+export const router = publicRoute.router({
   getUser: os
     .input(
       z.object({
@@ -39,8 +39,8 @@ export const router = publicProcedure.router({
       }
     }),
 
-  post: publicProcedure.prefix('/posts').router({
-    getPost: publicProcedure
+  post: publicRoute.prefix('/posts').router({
+    getPost: publicRoute
       .route({
         path: '/{id}', // custom your OpenAPI
         method: 'GET',
@@ -65,7 +65,7 @@ export const router = publicProcedure.router({
         }
       }),
 
-    createPost: authProcedure
+    createPost: authRoute
       .input(
         z.object({
           title: z.string(),

--- a/apps/content/content/docs/openapi/generator.mdx
+++ b/apps/content/content/docs/openapi/generator.mdx
@@ -18,32 +18,36 @@ import { z } from 'zod'
 
 export type Context = { user?: { id: string } }
 
-// global pub, authed completely optional
-export const pub /** public access */ = os.context<Context>()
-export const authed /** require authed */ = pub.use((input, context, meta) => /** put auth logic here */ meta.next({}))
+// global publicProcedure, authed completely optional
+export const publicProcedure = os.context<Context>()
+export const authProcedure = publicProcedure.use((input, context, meta) => {
+  /** put auth logic here */
+  return meta.next({})
+})
 
-export const router = pub.router({
-  getting: os
+export const router = publicProcedure.router({
+  getUser: os
     .input(
       z.object({
-        name: z.string(),
+        id: z.string(),
       }),
     )
     .handler(async (input, context, meta) => {
       return {
-        message: `Hello, ${input.name}!`,
+        id: input.id,
+        name: 'example',
       }
     }),
 
-  post: pub.prefix('/posts').router({
-    find: pub
+  post: publicProcedure.prefix('/posts').router({
+    getPost: publicProcedure
       .route({
         path: '/{id}', // custom your OpenAPI
         method: 'GET',
       })
       .input(
         z.object({
-          id: z.string({}),
+          id: z.string(),
         }),
       )
       .output(
@@ -61,7 +65,7 @@ export const router = pub.router({
         }
       }),
 
-    create: authed
+    createPost: authProcedure
       .input(
         z.object({
           title: z.string(),

--- a/apps/content/content/docs/server/context.mdx
+++ b/apps/content/content/docs/server/context.mdx
@@ -20,7 +20,7 @@ import { headers } from 'next/headers'
 type ORPCContext = { db: 'fake-db', user?: { id: string } }
 const base = os.context<ORPCContext>() // define `initial context`
 
-const publicRoute = os.context<ORPCContext>().use(async (input, context, meta) => {
+const pub = os.context<ORPCContext>().use(async (input, context, meta) => {
     const headersList = await headers()
 
     // the `user` is `middleware context`, because it is created by middleware
@@ -31,8 +31,8 @@ const publicRoute = os.context<ORPCContext>().use(async (input, context, meta) =
     })
 })
 
-export const router = publicRoute.router({
-    getUser: publicRoute.handler((input, context, meta) => {
+export const router = pub.router({
+    getUser: pub.handler((input, context, meta) => {
         // ^ context is combined from `initial context` and `middleware context`
     }),
 })

--- a/apps/content/content/docs/server/context.mdx
+++ b/apps/content/content/docs/server/context.mdx
@@ -20,7 +20,7 @@ import { headers } from 'next/headers'
 type ORPCContext = { db: 'fake-db', user?: { id: string } }
 const base = os.context<ORPCContext>() // define `initial context`
 
-const pub = os.context<ORPCContext>().use(async (input, context, meta) => {
+const publicProcedure = os.context<ORPCContext>().use(async (input, context, meta) => {
     const headersList = await headers()
 
     // the `user` is `middleware context`, because it is created by middleware
@@ -31,8 +31,8 @@ const pub = os.context<ORPCContext>().use(async (input, context, meta) => {
     })
 })
 
-export const router = pub.router({
-    getting: pub.handler((input, context, meta) => {
+export const router = publicProcedure.router({
+    getUser: publicProcedure.handler((input, context, meta) => {
         // ^ context is combined from `initial context` and `middleware context`
     }),
 })
@@ -72,7 +72,7 @@ const authMid = base.middleware(async (input, context, meta) => {
 })
 
 export const router = base.router({
-    getting: base
+    getUser: base
         .use(authMid)
         .handler((input, context, meta) => {
             // ^ context is fully typed
@@ -80,7 +80,7 @@ export const router = base.router({
 })
 
 // You can call this procedure directly without manually providing context
-const output = await router.getting()
+const output = await router.getUser()
 
 import { ORPCHandler } from '@orpc/server/fetch'
 import { OpenAPIServerlessHandler, OpenAPIServerHandler } from '@orpc/openapi/fetch'
@@ -121,7 +121,7 @@ const authMid = base.middleware((input, context, meta) => {
 })
 
 export const router = base.router({
-    getting: base
+    getUser: base
         .use(authMid)
         .handler((input, context, meta) => {
             // ^ context is fully typed
@@ -141,7 +141,7 @@ export function fetch(request: Request) {
 // If you want to call this procedure or use as server action
 //  you must create another client with context by using `createProcedureClient` or `createRouterClient`
 const client = createProcedureClient({
-    procedure: router.getting,
+    procedure: router.getUser,
     context: async () => {
         // some logic to create context
         return { 

--- a/apps/content/content/docs/server/context.mdx
+++ b/apps/content/content/docs/server/context.mdx
@@ -20,7 +20,7 @@ import { headers } from 'next/headers'
 type ORPCContext = { db: 'fake-db', user?: { id: string } }
 const base = os.context<ORPCContext>() // define `initial context`
 
-const publicProcedure = os.context<ORPCContext>().use(async (input, context, meta) => {
+const publicRoute = os.context<ORPCContext>().use(async (input, context, meta) => {
     const headersList = await headers()
 
     // the `user` is `middleware context`, because it is created by middleware
@@ -31,8 +31,8 @@ const publicProcedure = os.context<ORPCContext>().use(async (input, context, met
     })
 })
 
-export const router = publicProcedure.router({
-    getUser: publicProcedure.handler((input, context, meta) => {
+export const router = publicRoute.router({
+    getUser: publicRoute.handler((input, context, meta) => {
         // ^ context is combined from `initial context` and `middleware context`
     }),
 })

--- a/apps/content/content/docs/server/contract.mdx
+++ b/apps/content/content/docs/server/contract.mdx
@@ -83,16 +83,16 @@ import { contract } from 'examples/contract'
 
 export type Context = { user?: { id: string } }
 export const base = os.context<Context>()
-export const publicRoute = base.contract(contract) // Ensure every implement must be match contract
-export const authRoute = base
+export const pub = base.contract(contract) // Ensure every implement must be match contract
+export const authed = base
   .use((input, context, meta) => {
     /** put auth logic here */
     return meta.next({})
   })
   .contract(contract)
 
-export const router = publicRoute.router({
-  getUser: publicRoute.getUser.handler((input, context, meta) => {
+export const router = pub.router({
+  getUser: pub.getUser.handler((input, context, meta) => {
     return {
       username: 'example',
       avatar: 'example',
@@ -100,7 +100,7 @@ export const router = publicRoute.router({
   }),
 
   posts: {
-    getPost: publicRoute.posts.getPost
+    getPost: pub.posts.getPost
       .handler((input, context, meta) => {
         return {
           id: 'example',
@@ -109,7 +109,7 @@ export const router = publicRoute.router({
         }
       }),
 
-    createPost: authRoute.posts.createPost.handler((input, context, meta) => {
+    createPost: authed.posts.createPost.handler((input, context, meta) => {
       return {
         id: 'example',
         title: input.title,

--- a/apps/content/content/docs/server/contract.mdx
+++ b/apps/content/content/docs/server/contract.mdx
@@ -22,20 +22,21 @@ import { z } from 'zod'
 // This contract can replace server router in most-case
 
 export const contract = oc.router({
-  getting: oc
+  getUser: oc
     .input(
       z.object({
-        name: z.string(),
+        id: z.string(),
       }),
     )
     .output(
       z.object({
-        message: z.string(),
+        username: z.string(),
+        avatar: z.string(),
       }),
     ),
 
-  post: oc.prefix('/posts').router({
-    find: oc
+  posts: oc.prefix('/posts').router({
+    getPost: oc
       .route({
         path: '/{id}',
         method: 'GET',
@@ -53,7 +54,7 @@ export const contract = oc.router({
         }),
       ),
 
-    create: oc
+    createPost: oc
       .input(
         z.object({
           title: z.string(),
@@ -82,20 +83,24 @@ import { contract } from 'examples/contract'
 
 export type Context = { user?: { id: string } }
 export const base = os.context<Context>()
-export const pub /** public access */ = base.contract(contract) // Ensure every implement must be match contract
-export const authed /** require authed */ = base
-  .use((input, context, meta) => /** put auth logic here */ meta.next({}))
+export const publicProcedure = base.contract(contract) // Ensure every implement must be match contract
+export const authProcedure = base
+  .use((input, context, meta) => {
+    /** put auth logic here */
+    return meta.next({})
+  })
   .contract(contract)
 
-export const router = pub.router({
-  getting: pub.getting.handler((input, context, meta) => {
+export const router = publicProcedure.router({
+  getUser: publicProcedure.getUser.handler((input, context, meta) => {
     return {
-      message: `Hello, ${input.name}!`,
+      username: 'example',
+      avatar: 'example',
     }
   }),
 
-  post: {
-    find: pub.post.find
+  posts: {
+    getPost: publicProcedure.posts.getPost
       .handler((input, context, meta) => {
         return {
           id: 'example',
@@ -104,7 +109,7 @@ export const router = pub.router({
         }
       }),
 
-    create: authed.post.create.handler((input, context, meta) => {
+    createPost: authProcedure.posts.createPost.handler((input, context, meta) => {
       return {
         id: 'example',
         title: input.title,
@@ -126,6 +131,6 @@ import { contract } from 'examples/contract'
 type Inputs = InferContractRouterInputs<typeof contract>
 type Outputs = InferContractRouterOutputs<typeof contract>
 
-type GettingInput = Inputs['getting']
-type PostFindOutput = Outputs['post']['find']
+type GetUserInput = Inputs['getUser']
+type GetPostOutput = Outputs['posts']['getPost']
 ```

--- a/apps/content/content/docs/server/contract.mdx
+++ b/apps/content/content/docs/server/contract.mdx
@@ -83,16 +83,16 @@ import { contract } from 'examples/contract'
 
 export type Context = { user?: { id: string } }
 export const base = os.context<Context>()
-export const publicProcedure = base.contract(contract) // Ensure every implement must be match contract
-export const authProcedure = base
+export const publicRoute = base.contract(contract) // Ensure every implement must be match contract
+export const authRoute = base
   .use((input, context, meta) => {
     /** put auth logic here */
     return meta.next({})
   })
   .contract(contract)
 
-export const router = publicProcedure.router({
-  getUser: publicProcedure.getUser.handler((input, context, meta) => {
+export const router = publicRoute.router({
+  getUser: publicRoute.getUser.handler((input, context, meta) => {
     return {
       username: 'example',
       avatar: 'example',
@@ -100,7 +100,7 @@ export const router = publicProcedure.router({
   }),
 
   posts: {
-    getPost: publicProcedure.posts.getPost
+    getPost: publicRoute.posts.getPost
       .handler((input, context, meta) => {
         return {
           id: 'example',
@@ -109,7 +109,7 @@ export const router = publicProcedure.router({
         }
       }),
 
-    createPost: authProcedure.posts.createPost.handler((input, context, meta) => {
+    createPost: authRoute.posts.createPost.handler((input, context, meta) => {
       return {
         id: 'example',
         title: input.title,

--- a/apps/content/content/docs/server/lazy.mdx
+++ b/apps/content/content/docs/server/lazy.mdx
@@ -16,13 +16,13 @@ Here's how you can set up and use them:
 ```typescript twoslash
 import { os } from '@orpc/server'
 
-const publicProcedure = os.context<{ user?: { id: string } } | undefined>()
+const publicRoute = os.context<{ user?: { id: string } } | undefined>()
 
 // Define a router with lazy loading
-const router = publicProcedure.router({
-    lazy: publicProcedure.lazy(() => import('examples/server')),
+const router = publicRoute.router({
+    lazy: publicRoute.lazy(() => import('examples/server')),
     // Please use .prefix when you use OpenAPI
-    better: publicProcedure.prefix('/some').lazy(() => import('examples/server'))
+    better: publicRoute.prefix('/some').lazy(() => import('examples/server'))
 })
 
 // Use the lazy-loaded router as if it were a regular one
@@ -48,9 +48,9 @@ const output = await router.lazy.getUser({ id: '123' })
 
    ```ts twoslash
     import { os } from '@orpc/server'
-    const publicProcedure = os.context<{ user?: { id: string } }>()
+    const publicRoute = os.context<{ user?: { id: string } }>()
 
-    const lazy = publicProcedure.prefix('/some').lazy(() => import('examples/server'))
+    const lazy = publicRoute.prefix('/some').lazy(() => import('examples/server'))
     ```
 
     Adding a prefix helps oRPC dynamically load the router only when it's needed, 

--- a/apps/content/content/docs/server/lazy.mdx
+++ b/apps/content/content/docs/server/lazy.mdx
@@ -16,13 +16,13 @@ Here's how you can set up and use them:
 ```typescript twoslash
 import { os } from '@orpc/server'
 
-const publicRoute = os.context<{ user?: { id: string } } | undefined>()
+const pub = os.context<{ user?: { id: string } } | undefined>()
 
 // Define a router with lazy loading
-const router = publicRoute.router({
-    lazy: publicRoute.lazy(() => import('examples/server')),
+const router = pub.router({
+    lazy: pub.lazy(() => import('examples/server')),
     // Please use .prefix when you use OpenAPI
-    better: publicRoute.prefix('/some').lazy(() => import('examples/server'))
+    better: pub.prefix('/some').lazy(() => import('examples/server'))
 })
 
 // Use the lazy-loaded router as if it were a regular one
@@ -48,9 +48,9 @@ const output = await router.lazy.getUser({ id: '123' })
 
    ```ts twoslash
     import { os } from '@orpc/server'
-    const publicRoute = os.context<{ user?: { id: string } }>()
+    const pub = os.context<{ user?: { id: string } }>()
 
-    const lazy = publicRoute.prefix('/some').lazy(() => import('examples/server'))
+    const lazy = pub.prefix('/some').lazy(() => import('examples/server'))
     ```
 
     Adding a prefix helps oRPC dynamically load the router only when it's needed, 

--- a/apps/content/content/docs/server/lazy.mdx
+++ b/apps/content/content/docs/server/lazy.mdx
@@ -16,17 +16,17 @@ Here's how you can set up and use them:
 ```typescript twoslash
 import { os } from '@orpc/server'
 
-const pub = os.context<{ user?: { id: string } } | undefined>()
+const publicProcedure = os.context<{ user?: { id: string } } | undefined>()
 
 // Define a router with lazy loading
-const router = pub.router({
-    lazy: pub.lazy(() => import('examples/server')),
+const router = publicProcedure.router({
+    lazy: publicProcedure.lazy(() => import('examples/server')),
     // Please use .prefix when you use OpenAPI
-    better: pub.prefix('/some').lazy(() => import('examples/server'))
+    better: publicProcedure.prefix('/some').lazy(() => import('examples/server'))
 })
 
 // Use the lazy-loaded router as if it were a regular one
-const output = await router.lazy.getting({ name: 'unnoq' })
+const output = await router.lazy.getUser({ id: '123' })
 ```
 
 ### Key Points:
@@ -48,9 +48,9 @@ const output = await router.lazy.getting({ name: 'unnoq' })
 
    ```ts twoslash
     import { os } from '@orpc/server'
-    const pub = os.context<{ user?: { id: string } }>()
+    const publicProcedure = os.context<{ user?: { id: string } }>()
 
-    const lazy = pub.prefix('/some').lazy(() => import('examples/server'))
+    const lazy = publicProcedure.prefix('/some').lazy(() => import('examples/server'))
     ```
 
     Adding a prefix helps oRPC dynamically load the router only when it's needed, 

--- a/apps/content/content/docs/server/middleware.mdx
+++ b/apps/content/content/docs/server/middleware.mdx
@@ -12,9 +12,9 @@ import { os, ORPCError } from '@orpc/server'
 
 export type Context = { user?: { id: string } }
 
-export const pub /** public access */ = os.context<Context>()
+export const publicProcedure = os.context<Context>()
 
-const authMiddleware = pub.middleware(async (input, context, meta) => {
+const authMiddleware = publicProcedure.middleware(async (input, context, meta) => {
     if (!context.user) {
         throw new ORPCError({
             code: 'UNAUTHORIZED',
@@ -34,7 +34,7 @@ const authMiddleware = pub.middleware(async (input, context, meta) => {
 })
 
 // Now every procedure or router defined in this oRPC will be protected by authMiddleware
-export const authed /** require authed */ = pub.use(authMiddleware)
+export const authed /** require authed */ = publicProcedure.use(authMiddleware)
 ```
 
 ## Typed Input
@@ -86,10 +86,10 @@ type Context = {
     }
 }
 
-export const pub = os.context<Context>()
+export const publicProcedure = os.context<Context>()
 
 // Any procedure using this middleware will infer context.user as NonNullable<typeof context['user']>
-const authMiddleware = pub
+const authMiddleware = publicProcedure
     .middleware(async (input, context, meta) => {
         if (!context.user) {
             throw new ORPCError({ code: 'UNAUTHORIZED' })
@@ -102,7 +102,7 @@ const authMiddleware = pub
         })
     })
 
-export const authed = pub
+export const authed = publicProcedure
     .use(authMiddleware)
     .use((input, context, meta) => {
 

--- a/apps/content/content/docs/server/middleware.mdx
+++ b/apps/content/content/docs/server/middleware.mdx
@@ -12,9 +12,9 @@ import { os, ORPCError } from '@orpc/server'
 
 export type Context = { user?: { id: string } }
 
-export const publicRoute = os.context<Context>()
+export const pub = os.context<Context>()
 
-const authMiddleware = publicRoute.middleware(async (input, context, meta) => {
+const authMiddleware = pub.middleware(async (input, context, meta) => {
     if (!context.user) {
         throw new ORPCError({
             code: 'UNAUTHORIZED',
@@ -34,7 +34,7 @@ const authMiddleware = publicRoute.middleware(async (input, context, meta) => {
 })
 
 // Now every procedure or router defined in this oRPC will be protected by authMiddleware
-export const authed /** require authed */ = publicRoute.use(authMiddleware)
+export const authed /** require authed */ = pub.use(authMiddleware)
 ```
 
 ## Typed Input
@@ -86,10 +86,10 @@ type Context = {
     }
 }
 
-export const publicRoute = os.context<Context>()
+export const pub = os.context<Context>()
 
 // Any procedure using this middleware will infer context.user as NonNullable<typeof context['user']>
-const authMiddleware = publicRoute
+const authMiddleware = pub
     .middleware(async (input, context, meta) => {
         if (!context.user) {
             throw new ORPCError({ code: 'UNAUTHORIZED' })
@@ -102,7 +102,7 @@ const authMiddleware = publicRoute
         })
     })
 
-export const authed = publicRoute
+export const authed = pub
     .use(authMiddleware)
     .use((input, context, meta) => {
 

--- a/apps/content/content/docs/server/middleware.mdx
+++ b/apps/content/content/docs/server/middleware.mdx
@@ -12,9 +12,9 @@ import { os, ORPCError } from '@orpc/server'
 
 export type Context = { user?: { id: string } }
 
-export const publicProcedure = os.context<Context>()
+export const publicRoute = os.context<Context>()
 
-const authMiddleware = publicProcedure.middleware(async (input, context, meta) => {
+const authMiddleware = publicRoute.middleware(async (input, context, meta) => {
     if (!context.user) {
         throw new ORPCError({
             code: 'UNAUTHORIZED',
@@ -34,7 +34,7 @@ const authMiddleware = publicProcedure.middleware(async (input, context, meta) =
 })
 
 // Now every procedure or router defined in this oRPC will be protected by authMiddleware
-export const authed /** require authed */ = publicProcedure.use(authMiddleware)
+export const authed /** require authed */ = publicRoute.use(authMiddleware)
 ```
 
 ## Typed Input
@@ -86,10 +86,10 @@ type Context = {
     }
 }
 
-export const publicProcedure = os.context<Context>()
+export const publicRoute = os.context<Context>()
 
 // Any procedure using this middleware will infer context.user as NonNullable<typeof context['user']>
-const authMiddleware = publicProcedure
+const authMiddleware = publicRoute
     .middleware(async (input, context, meta) => {
         if (!context.user) {
             throw new ORPCError({ code: 'UNAUTHORIZED' })
@@ -102,7 +102,7 @@ const authMiddleware = publicProcedure
         })
     })
 
-export const authed = publicProcedure
+export const authed = publicRoute
     .use(authMiddleware)
     .use((input, context, meta) => {
 

--- a/apps/content/content/docs/server/procedure.mdx
+++ b/apps/content/content/docs/server/procedure.mdx
@@ -20,9 +20,9 @@ import { z } from 'zod'
 import { os, ORPCError } from '@orpc/server'
 
 // Define context type for full type inference
-const pub /* public access */ = os.context<{user?: {id: string}}>()
+const publicProcedure = os.context<{user?: {id: string}}>()
 
-const findUser = pub
+const getUser = publicProcedure
     .route({ method: 'GET', path: '/{id}' }) // Optional: if you want custom api under OpenAPI Specifications
     .input(z.object({ id: z.string() })) // Optional
     .output(z.object({ id: z.string(), name: z.string() })) // Optional

--- a/apps/content/content/docs/server/procedure.mdx
+++ b/apps/content/content/docs/server/procedure.mdx
@@ -20,9 +20,9 @@ import { z } from 'zod'
 import { os, ORPCError } from '@orpc/server'
 
 // Define context type for full type inference
-const publicRoute = os.context<{user?: {id: string}}>()
+const pub = os.context<{user?: {id: string}}>()
 
-const getUser = publicRoute
+const getUser = pub
     .route({ method: 'GET', path: '/{id}' }) // Optional: if you want custom api under OpenAPI Specifications
     .input(z.object({ id: z.string() })) // Optional
     .output(z.object({ id: z.string(), name: z.string() })) // Optional

--- a/apps/content/content/docs/server/procedure.mdx
+++ b/apps/content/content/docs/server/procedure.mdx
@@ -20,9 +20,9 @@ import { z } from 'zod'
 import { os, ORPCError } from '@orpc/server'
 
 // Define context type for full type inference
-const publicProcedure = os.context<{user?: {id: string}}>()
+const publicRoute = os.context<{user?: {id: string}}>()
 
-const getUser = publicProcedure
+const getUser = publicRoute
     .route({ method: 'GET', path: '/{id}' }) // Optional: if you want custom api under OpenAPI Specifications
     .input(z.object({ id: z.string() })) // Optional
     .output(z.object({ id: z.string(), name: z.string() })) // Optional

--- a/apps/content/content/docs/server/router.mdx
+++ b/apps/content/content/docs/server/router.mdx
@@ -10,19 +10,20 @@ A router is a collection of procedures with utilities that help reduce code dupl
 ```ts twoslash
 import { os } from '@orpc/server'
 
-const findUser = os.route({path: '/'}).handler(() => {})
+const getUserHandler = os.route({ path: '/' }).handler(() => {})
+
+export const usersRouter = os.prefix('/users').router({
+    getUser: getUserHandler,
+})
 
 export const appRouter = os.router({
-    user: {
-        find: findUser,
-    },
-
-    nested: os
+    users: os
         .prefix('/users')  // Prefix will be concatenated with paths defined in route(...)
-        .use((input, context, meta) => /* Logic applies for all routes in this router */ meta.next({}))
-        .router({
-            find: findUser,
-        }),
+        .use((input, context, meta) => {
+            /* Logic applies for all routes in this router */
+            return meta.next({})
+        })
+        .router(usersRouter),
 })
 ```
 
@@ -36,7 +37,7 @@ You can add a prefix to all routes in a router:
 ```ts twoslash
 import { os } from '@orpc/server'
 
-const userRouter = os
+const usersRouter = os
     .prefix('/users')
     .router({
         // ...
@@ -68,22 +69,22 @@ Create hierarchical route structures:
 ```ts twoslash
 import { os } from '@orpc/server'
 
-const userRouter = os.router({
+const usersRouter = os.router({
     // ...
 })
 
-const postRouter = os.router({
+const postsRouter = os.router({
     // ...
 })
 
-const commentRouter = os.router({
+const commentsRouter = os.router({
     // ...
 })
 
 const apiRouter = os.router({
-    users: userRouter,
-    posts: postRouter,
-    comments: os.prefix('/comments').router(commentRouter),
+    users: usersRouter,
+    posts: postsRouter,
+    comments: os.prefix('/comments').router(commentsRouter),
 })
 ```
 
@@ -99,6 +100,6 @@ import { router } from 'examples/server'
 type Inputs = InferRouterInputs<typeof router>
 type Outputs = InferRouterOutputs<typeof router>
 
-type GettingInput = Inputs['getting']
-type PostFindOutput = Outputs['post']['find']
+type GetUserInput = Inputs['getUser']
+type GetPostOutput = Outputs['posts']['getPost']
 ```

--- a/apps/content/content/home/client.mdx
+++ b/apps/content/content/home/client.mdx
@@ -14,15 +14,15 @@ const orpcLink = new ORPCLink({
 const client = createORPCClient<typeof router /* or contract router */>(orpcLink)
  
 //  File upload out of the box
-const output = await client.post.create({
+const output = await client.posts.createPost({
   title: 'My Amazing Title',
   description: 'This is a detailed description of my content',
   thumb: (document.getElementById('thumb') as HTMLInputElement).files[0]!,
 })
 
 // @noErrors
-client.post.
-//          ^|
+client.posts.
+//           ^|
 
 
 
@@ -31,7 +31,7 @@ client.post.
 
 
 try {
-  const post = await client.post.find({ id: 'example' })
+  const post = await client.posts.getPost({ id: 'example' })
 } catch (error) {
   if (error instanceof ORPCError) {
     // handle error
@@ -59,13 +59,13 @@ export const { orpc, ORPCContext } = createORPCReact<RouterClient<typeof router 
 
 // ------------------ Example ------------------
 
-const { data: gettingData } = orpc.getting.useQuery({ name: 'unnoq' })
-const { data: postData } = orpc.post.find.useQuery({ id: 'example' })
-const { mutate: postMutate } = orpc.post.create.useMutation()
+const { data: gettingData } = orpc.getUser.useQuery({ id: '123' })
+const { data: postData } = orpc.posts.getPost.useQuery({ id: 'example' })
+const { mutate: postMutate } = orpc.posts.createPost.useMutation()
 
 // @noErrors
-orpc.post.find.
-//             ^|
+orpc.posts.getPost.
+//                 ^|
 
 
 
@@ -79,11 +79,11 @@ orpc.post.find.
 
 const utils = orpc.useUtils()
 utils.invalidate() // invalidate all queries
-const data = await utils.getting.fetchQuery({ name: 'unnoq' })
+const data = await utils.getUser.fetchQuery({ id: '123' })
 
 // @noErrors
-utils.post.find.
-//              ^|
+utils.posts.getPost.
+//                  ^|
 
 
 
@@ -115,8 +115,8 @@ utils.post.find.
 
 
 const queries = orpc.useQueries(o => [
-  o.getting({ name: 'unnoq' }), 
-  o.post.find({ id: 'example' })
+  o.getUser({ id: '123' }), 
+  o.posts.getPost({ id: 'example' })
 ])
 
 // ------------------ Provider ------------------
@@ -153,23 +153,23 @@ import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from '@tansta
 import { orpc } from 'examples/react-query'
 
 // Fetch data
-const { data: gettingData } = useQuery(orpc.getting.queryOptions({ input: { name: 'unnoq' } }))
+const { data: gettingData } = useQuery(orpc.getUser.queryOptions({ input: { id: '123' } }))
 
 // Use suspense query
 const { data: postData } = useSuspenseQuery(
-  orpc.post.find.queryOptions({ input: { id: 'example' } }),
+  orpc.posts.getPost.queryOptions({ input: { id: 'example' } }),
 )
 
 // Perform mutations
-const { mutate: postMutate } = useMutation(orpc.post.create.mutationOptions())
+const { mutate: postMutate } = useMutation(orpc.posts.createPost.mutationOptions())
 
 // Invalidate queries
 const queryClient = useQueryClient()
 queryClient.invalidateQueries({ queryKey: orpc.key() }) // Invalidate all queries
-queryClient.invalidateQueries({ queryKey: orpc.post.find.key({ input: { id: 'example' } }) }) // Specific queries
+queryClient.invalidateQueries({ queryKey: orpc.posts.getPost.key({ input: { id: 'example' } }) }) // Specific queries
 
 // @noErrors
-orpc.getting.
+orpc.getUser.
 //           ^|
 
 
@@ -191,18 +191,18 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/vue-query'
 import { orpc } from 'examples/vue-query'
 
 // Fetch data
-const { data: gettingData } = useQuery(orpc.getting.queryOptions({ input: { name: 'unnoq' } }))
+const { data: gettingData } = useQuery(orpc.getUser.queryOptions({ input: { id: '123' } }))
 
 // Perform mutations
-const { mutate: postMutate } = useMutation(orpc.post.create.mutationOptions())
+const { mutate: postMutate } = useMutation(orpc.posts.createPost.mutationOptions())
 
 // Invalidate queries
 const queryClient = useQueryClient()
 queryClient.invalidateQueries({ queryKey: orpc.key() }) // Invalidate all queries
-queryClient.invalidateQueries({ queryKey: orpc.post.find.key({ input: { id: 'example' } }) }) // Specific queries
+queryClient.invalidateQueries({ queryKey: orpc.posts.getPost.key({ input: { id: 'example' } }) }) // Specific queries
 
 // @noErrors
-orpc.getting.
+orpc.getUser.
 //           ^|
 
 
@@ -223,11 +223,11 @@ orpc.getting.
 
 <Tab value="CURL">
 ```bash
-curl --request POST \
-  --url http://localhost:3000/api/getting \
+curl --request GET \
+  --url http://localhost:3000/api/users \
   --header 'Content-Type: application/json' \
   --data '{
-    "name": "unnoq"
+    "id": "123"
   }'
 ```
 

--- a/apps/content/content/home/landing.mdx
+++ b/apps/content/content/home/landing.mdx
@@ -128,9 +128,9 @@ Learn more about [Server Action](/docs/server/server-action).
 ```tsx
 type ORPCContext = { db: DB, user?: { id: string } }
 
-const publicRoute = os.context<ORPCContext>()
+const pub = os.context<ORPCContext>()
 
-const createPost = publicRoute
+const createPost = pub
 	.use((input, context, meta) => {
 		if(!context.user){
 			throw new ORPCError({ code: 'UNAUTHORIZED' })

--- a/apps/content/content/home/landing.mdx
+++ b/apps/content/content/home/landing.mdx
@@ -1,12 +1,12 @@
 ## Build Robust, Typesafe Functions
 
 ```tsx
-export const getting = os
+export const updateUser = os
 	.use(authMiddleware) // require auth
 	.use(cache('5m')) // cache the output
 	.route({
-		path: '/getting/{id}' // dynamic params support
-		method: 'POST' // custom OpenAPI method
+		path: '/users/{id}' // dynamic params support
+		method: 'PATCH' // custom OpenAPI method
 	})
 	.input(z.object({
 		id: z.bigint(),
@@ -16,8 +16,8 @@ export const getting = os
 		})
 	}))
 	.use(canMiddleware, (i) => i.id) // permission check by id
-	.output(z.string()) // validate output
-	.handler(async (input) => 'Name and Avatar has been updated')
+	.output(z.literal("success")) // validate output
+	.handler(async (input) => /* handle user update */)
 ```
 
 > Only the `.handler` method is required. All other chain methods are optional.
@@ -29,7 +29,7 @@ you can create **reusable logic** that ensures **type safety** and adds **power*
 ## Use as a Regular Function
 
 ```tsx
-const text = await getting({ 
+const updatedUser = await updateUser({ 
 	id: 1992n,
 	user: {
 		name: 'unnoq',
@@ -40,10 +40,10 @@ const text = await getting({
 
 The [Procedure Client](/docs/server/client) feature lets your procedures behave like regular TypeScript functions.
 
-## Expose It Online with a Fully Typed Client
+## Expose It In Your Frontend with a Fully Typed Client
 
 ```tsx
-const text = await orpc.getting({ 
+const updatedUser = await orpc.updateUser({ 
 	id: 1992n,
 	user: {
 		name: 'unnoq',
@@ -59,15 +59,15 @@ Our [Vanilla Client](/docs/client/vanilla) is fully typed and doesn't rely on ge
 ```ts
 // Fetch data with oRPC
 const { data, status } = useQuery(
-  orpc.post.find.queryOptions({ input: { id: 'example' } })
+  orpc.posts.getPost.queryOptions({ input: { id: 'example' } })
 );
 
 // Perform a mutation and invalidate related queries on success
 const { mutate, isPending } = useMutation(
-  orpc.getting.mutationOptions({
+  orpc.updateUser.mutationOptions({
     onSuccess() {
       queryClient.invalidateQueries({
-        queryKey: orpc.post.find.key({ input: { id: 'example' } }),
+        queryKey: orpc.post.getPost.key({ input: { id: 'example' } }),
       });
     },
   })
@@ -88,7 +88,7 @@ We now support [React Query Integration](/docs/client/react-query) and [Vue Quer
 ## Access via OpenAPI Standard
 
 ```bash
-curl -X POST http://localhost:2026/api/getting/1992 \
+curl -X PATCH https://example.com/api/users/1992 \
   -H "Content-Type: multipart/form-data" \
   -F "user[name]=unnoq" \
   -F "user[avatar]=@/path/to/your/image.jpg"
@@ -101,19 +101,18 @@ convert `1992` into a `bigint` and seamlessly parse objects like `user`.
 
 ```tsx
 // call directly from client
-const onSubmit = () => { getting({ /***/ }) }
+const onSubmit = () => { updateUser({ /***/ }) }
 // use with a hook
-const { execute, isPending, isError, error, output, input, status } = useAction(getting)
+const { execute, isPending, isError, error, output, input, status } = useAction(updateUser)
 // createSafeAction and useSafeAction if you want catch error on client
 // use as a form action
-const gettingFA = createFormAction({ 
-	procedure: getting,
+const updateUserFA = createFormAction({ 
+	procedure: updateUser,
 	schemaCoercers: [new ZodCoercer()],
 	onSuccess: () => redirect('/some-where')
 })
 
-
-<form action={gettingFA}>
+<form action={updateUserFA}>
   <input type="number" name="id" value="1992" />
   <input type="string" name="user[name]" value="unnoq" />
   <input type="file" name="user[avatar]" accept="image/*" />
@@ -129,9 +128,9 @@ Learn more about [Server Action](/docs/server/server-action).
 ```tsx
 type ORPCContext = { db: DB, user?: { id: string } }
 
-const pub /* public access */ = os.context<ORPCContext>()
+const publicProcedure = os.context<ORPCContext>()
 
-const getting = pub
+const createPost = publicProcedure
 	.use((input, context, meta) => {
 		if(!context.user){
 			throw new ORPCError({ code: 'UNAUTHORIZED' })
@@ -153,14 +152,14 @@ When you use [Initial Context](/docs/server/context#initial-context), every call
 ## **Contract-First Development**
 
 ```tsx
-const gettingContract = oc
+const userContract = oc
 	.route({/*something*/})
 	.input({/*something*/})
 	.output({/*something*/})
-	
-const getting = os
-	.contract(gettingContract)
-	.handler(async () => 'Worked')
+
+// All nested procedures will be embedded in the parent contract
+const contract = os
+	.contract(userContract)
 ```
 
 With [oRPC's Contract First Development](/docs/server/contract), you can easily separate the procedure's definition 

--- a/apps/content/content/home/landing.mdx
+++ b/apps/content/content/home/landing.mdx
@@ -128,9 +128,9 @@ Learn more about [Server Action](/docs/server/server-action).
 ```tsx
 type ORPCContext = { db: DB, user?: { id: string } }
 
-const publicProcedure = os.context<ORPCContext>()
+const publicRoute = os.context<ORPCContext>()
 
-const createPost = publicProcedure
+const createPost = publicRoute
 	.use((input, context, meta) => {
 		if(!context.user){
 			throw new ORPCError({ code: 'UNAUTHORIZED' })

--- a/apps/content/examples/contract.ts
+++ b/apps/content/examples/contract.ts
@@ -8,20 +8,25 @@ import { z } from 'zod'
 // This contract can replace server router in most-case
 
 export const contract = oc.router({
-  getting: oc
+  getUser: oc
+    .route({
+      path: '/{id}',
+      method: 'GET',
+    })
     .input(
       z.object({
-        name: z.string(),
+        id: z.string(),
       }),
     )
     .output(
       z.object({
-        message: z.string(),
+        username: z.string(),
+        avatar: z.string(),
       }),
     ),
 
-  post: oc.prefix('/posts').router({
-    find: oc
+  posts: oc.prefix('/posts').router({
+    getPost: oc
       .route({
         path: '/{id}',
         method: 'GET',
@@ -39,7 +44,7 @@ export const contract = oc.router({
         }),
       ),
 
-    create: oc
+    createPost: oc
       .input(
         z.object({
           title: z.string(),
@@ -64,20 +69,24 @@ export type Outputs = InferContractRouterOutputs<typeof contract>
 
 export type Context = { user?: { id: string } }
 export const base = os.context<Context>()
-export const pub /** os with ... */ = base.contract(contract) // Ensure every implement must be match contract
-export const authed /** require authed */ = base
-  .use((input, context, meta) => /** put auth logic here */ meta.next({}))
+export const publicProcedure = base.contract(contract) // Ensure every implement must be match contract
+export const authProcedure = base
+  .use((input, context, meta) => {
+    /** put auth logic here */
+    return meta.next({})
+  })
   .contract(contract)
 
-export const router = pub.router({
-  getting: pub.getting.handler((input, context, meta) => {
+export const router = publicProcedure.router({
+  getUser: publicProcedure.getUser.handler((input, context, meta) => {
     return {
-      message: `Hello, ${input.name}!`,
+      username: `user_${input.id}`,
+      avatar: `avatar_${input.id}.png`,
     }
   }),
 
-  post: {
-    find: pub.post.find
+  posts: {
+    getPost: publicProcedure.posts.getPost
       .use(async (input, context, meta) => {
         if (!context.user) {
           throw new ORPCError({
@@ -103,7 +112,7 @@ export const router = pub.router({
         }
       }),
 
-    create: authed.post.create.handler((input, context, meta) => {
+    createPost: authProcedure.posts.createPost.handler((input, context, meta) => {
       return {
         id: 'example',
         title: input.title,

--- a/apps/content/examples/contract.ts
+++ b/apps/content/examples/contract.ts
@@ -69,16 +69,16 @@ export type Outputs = InferContractRouterOutputs<typeof contract>
 
 export type Context = { user?: { id: string } }
 export const base = os.context<Context>()
-export const publicProcedure = base.contract(contract) // Ensure every implement must be match contract
-export const authProcedure = base
+export const publicRoute = base.contract(contract) // Ensure every implement must be match contract
+export const authRoute = base
   .use((input, context, meta) => {
     /** put auth logic here */
     return meta.next({})
   })
   .contract(contract)
 
-export const router = publicProcedure.router({
-  getUser: publicProcedure.getUser.handler((input, context, meta) => {
+export const router = publicRoute.router({
+  getUser: publicRoute.getUser.handler((input, context, meta) => {
     return {
       username: `user_${input.id}`,
       avatar: `avatar_${input.id}.png`,
@@ -86,7 +86,7 @@ export const router = publicProcedure.router({
   }),
 
   posts: {
-    getPost: publicProcedure.posts.getPost
+    getPost: publicRoute.posts.getPost
       .use(async (input, context, meta) => {
         if (!context.user) {
           throw new ORPCError({
@@ -112,7 +112,7 @@ export const router = publicProcedure.router({
         }
       }),
 
-    createPost: authProcedure.posts.createPost.handler((input, context, meta) => {
+    createPost: authRoute.posts.createPost.handler((input, context, meta) => {
       return {
         id: 'example',
         title: input.title,

--- a/apps/content/examples/contract.ts
+++ b/apps/content/examples/contract.ts
@@ -69,16 +69,16 @@ export type Outputs = InferContractRouterOutputs<typeof contract>
 
 export type Context = { user?: { id: string } }
 export const base = os.context<Context>()
-export const publicRoute = base.contract(contract) // Ensure every implement must be match contract
-export const authRoute = base
+export const pub = base.contract(contract) // Ensure every implement must be match contract
+export const authed = base
   .use((input, context, meta) => {
     /** put auth logic here */
     return meta.next({})
   })
   .contract(contract)
 
-export const router = publicRoute.router({
-  getUser: publicRoute.getUser.handler((input, context, meta) => {
+export const router = pub.router({
+  getUser: pub.getUser.handler((input, context, meta) => {
     return {
       username: `user_${input.id}`,
       avatar: `avatar_${input.id}.png`,
@@ -86,7 +86,7 @@ export const router = publicRoute.router({
   }),
 
   posts: {
-    getPost: publicRoute.posts.getPost
+    getPost: pub.posts.getPost
       .use(async (input, context, meta) => {
         if (!context.user) {
           throw new ORPCError({
@@ -112,7 +112,7 @@ export const router = publicRoute.router({
         }
       }),
 
-    createPost: authRoute.posts.createPost.handler((input, context, meta) => {
+    createPost: authed.posts.createPost.handler((input, context, meta) => {
       return {
         id: 'example',
         title: input.title,

--- a/apps/content/examples/middleware.ts
+++ b/apps/content/examples/middleware.ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
 
 export type Context = { user?: { id: string } }
 
-export const pub /** public access */ = os
+export const publicProcedure = os
   .context<Context>()
   .use(async (input, context, meta) => {
     // This middleware will apply to everything create from pub
@@ -20,7 +20,7 @@ export const pub /** public access */ = os
     }
   })
 
-export const authMid = pub.middleware(async (input, context, meta) => {
+export const authMiddleware = publicProcedure.middleware(async (input, context, meta) => {
   if (!context.user) {
     throw new ORPCError({ code: 'UNAUTHORIZED' })
   }
@@ -33,9 +33,9 @@ export const authMid = pub.middleware(async (input, context, meta) => {
   return result
 })
 
-export const authed = pub.use(authMid) // any procedure compose from authOS will be protected
+export const authed = publicProcedure.use(authMiddleware) // any procedure compose from authOS will be protected
 
-export const canEditPost = authMid.concat(
+export const canEditPost = authMiddleware.concat(
   // Now you expect to have id in input
   async (input: { id: string }, context, meta) => {
     if (context.user.id !== input.id) {

--- a/apps/content/examples/middleware.ts
+++ b/apps/content/examples/middleware.ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
 
 export type Context = { user?: { id: string } }
 
-export const publicRoute = os
+export const pub = os
   .context<Context>()
   .use(async (input, context, meta) => {
     // This middleware will apply to everything create from pub
@@ -20,7 +20,7 @@ export const publicRoute = os
     }
   })
 
-export const authMiddleware = publicRoute.middleware(async (input, context, meta) => {
+export const authMiddleware = pub.middleware(async (input, context, meta) => {
   if (!context.user) {
     throw new ORPCError({ code: 'UNAUTHORIZED' })
   }
@@ -33,7 +33,7 @@ export const authMiddleware = publicRoute.middleware(async (input, context, meta
   return result
 })
 
-export const authed = publicRoute.use(authMiddleware) // any procedure compose from authOS will be protected
+export const authed = pub.use(authMiddleware) // any procedure compose from authOS will be protected
 
 export const canEditPost = authMiddleware.concat(
   // Now you expect to have id in input

--- a/apps/content/examples/middleware.ts
+++ b/apps/content/examples/middleware.ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
 
 export type Context = { user?: { id: string } }
 
-export const publicProcedure = os
+export const publicRoute = os
   .context<Context>()
   .use(async (input, context, meta) => {
     // This middleware will apply to everything create from pub
@@ -20,7 +20,7 @@ export const publicProcedure = os
     }
   })
 
-export const authMiddleware = publicProcedure.middleware(async (input, context, meta) => {
+export const authMiddleware = publicRoute.middleware(async (input, context, meta) => {
   if (!context.user) {
     throw new ORPCError({ code: 'UNAUTHORIZED' })
   }
@@ -33,7 +33,7 @@ export const authMiddleware = publicProcedure.middleware(async (input, context, 
   return result
 })
 
-export const authed = publicProcedure.use(authMiddleware) // any procedure compose from authOS will be protected
+export const authed = publicRoute.use(authMiddleware) // any procedure compose from authOS will be protected
 
 export const canEditPost = authMiddleware.concat(
   // Now you expect to have id in input

--- a/apps/content/examples/open-api.ts
+++ b/apps/content/examples/open-api.ts
@@ -30,9 +30,9 @@ const _exampleSpec = {
   },
   openapi: '3.1.0',
   paths: {
-    '/getting': {
-      post: {
-        operationId: 'getting',
+    '/users': {
+      get: {
+        operationId: 'user.get',
         requestBody: {
           required: false,
           content: {
@@ -40,11 +40,11 @@ const _exampleSpec = {
               schema: {
                 type: 'object',
                 properties: {
-                  name: {
+                  id: {
                     type: 'string',
                   },
                 },
-                required: ['name'],
+                required: ['id'],
               },
             },
           },
@@ -57,11 +57,14 @@ const _exampleSpec = {
                 schema: {
                   type: 'object',
                   properties: {
-                    message: {
+                    username: {
+                      type: 'string',
+                    },
+                    avatar: {
                       type: 'string',
                     },
                   },
-                  required: ['message'],
+                  required: ['username', 'avatar'],
                 },
               },
             },
@@ -71,7 +74,7 @@ const _exampleSpec = {
     },
     '/posts/{id}': {
       get: {
-        operationId: 'post.find',
+        operationId: 'post.get',
         parameters: [
           {
             name: 'id',

--- a/apps/content/examples/server.ts
+++ b/apps/content/examples/server.ts
@@ -5,14 +5,14 @@ import { z } from 'zod'
 
 export type Context = { user?: { id: string } } | undefined
 
-// global publicRoute, authRoute completely optional
-export const publicRoute = os.context<Context>()
-export const authRoute = publicRoute.use((input, context, meta) => {
+// global pub, authed completely optional
+export const pub = os.context<Context>()
+export const authed = pub.use((input, context, meta) => {
   /** put auth logic here */
   return meta.next({})
 })
 
-export const router = publicRoute.router({
+export const router = pub.router({
   getUser: os
     .input(
       z.object({
@@ -26,8 +26,8 @@ export const router = publicRoute.router({
       }
     }),
 
-  posts: publicRoute.prefix('/posts').router({
-    getPost: publicRoute
+  posts: pub.prefix('/posts').router({
+    getPost: pub
       .route({
         path: '/{id}', // custom your OpenAPI
         method: 'GET',
@@ -69,7 +69,7 @@ export const router = publicRoute.router({
         }
       }),
 
-    createPost: authRoute
+    createPost: authed
       .input(
         z.object({
           title: z.string(),

--- a/apps/content/examples/server.ts
+++ b/apps/content/examples/server.ts
@@ -5,32 +5,36 @@ import { z } from 'zod'
 
 export type Context = { user?: { id: string } } | undefined
 
-// global pub, authed completely optional
-export const pub /** public access */ = os.context<Context>()
-export const authed /** require authed */ = pub.use((input, context, meta) => /** put auth logic here */ meta.next({}))
+// global publicProcedure, authProcedure completely optional
+export const publicProcedure = os.context<Context>()
+export const authProcedure = publicProcedure.use((input, context, meta) => {
+  /** put auth logic here */
+  return meta.next({})
+})
 
-export const router = pub.router({
-  getting: os
+export const router = publicProcedure.router({
+  getUser: os
     .input(
       z.object({
-        name: z.string(),
+        id: z.string(),
       }),
     )
     .handler(async (input, context, meta) => {
       return {
-        message: `Hello, ${input.name}!`,
+        id: input.id,
+        name: 'example',
       }
     }),
 
-  post: pub.prefix('/posts').router({
-    find: pub
+  posts: publicProcedure.prefix('/posts').router({
+    getPost: publicProcedure
       .route({
         path: '/{id}', // custom your OpenAPI
         method: 'GET',
       })
       .input(
         z.object({
-          id: z.string({}),
+          id: z.string(),
         }),
       )
       .output(
@@ -65,7 +69,7 @@ export const router = pub.router({
         }
       }),
 
-    create: authed
+    createPost: authProcedure
       .input(
         z.object({
           title: z.string(),

--- a/apps/content/examples/server.ts
+++ b/apps/content/examples/server.ts
@@ -5,14 +5,14 @@ import { z } from 'zod'
 
 export type Context = { user?: { id: string } } | undefined
 
-// global publicProcedure, authProcedure completely optional
-export const publicProcedure = os.context<Context>()
-export const authProcedure = publicProcedure.use((input, context, meta) => {
+// global publicRoute, authRoute completely optional
+export const publicRoute = os.context<Context>()
+export const authRoute = publicRoute.use((input, context, meta) => {
   /** put auth logic here */
   return meta.next({})
 })
 
-export const router = publicProcedure.router({
+export const router = publicRoute.router({
   getUser: os
     .input(
       z.object({
@@ -26,8 +26,8 @@ export const router = publicProcedure.router({
       }
     }),
 
-  posts: publicProcedure.prefix('/posts').router({
-    getPost: publicProcedure
+  posts: publicRoute.prefix('/posts').router({
+    getPost: publicRoute
       .route({
         path: '/{id}', // custom your OpenAPI
         method: 'GET',
@@ -69,7 +69,7 @@ export const router = publicProcedure.router({
         }
       }),
 
-    createPost: authProcedure
+    createPost: authRoute
       .input(
         z.object({
           title: z.string(),


### PR DESCRIPTION
The examples in the docs have some confusing naming patterns like using "getting" for getting a user etc instead of something more understandable like "getUser", so I've simplified the examples to be more understandable from first look by providing more context.