### PR TITLE
feat(server): added express adapter

### DIFF
--- a/apps/content/content/docs/server/integrations.mdx
+++ b/apps/content/content/docs/server/integrations.mdx
@@ -67,24 +67,26 @@ server.listen(3000, () => {
 import express from 'express'
 import { ORPCHandler, CompositeHandler } from '@orpc/server/node'
 import { OpenAPIServerlessHandler } from '@orpc/openapi/node'
+import { expressAdapter } from '@orpc/server/express'
 import { router } from 'examples/server'
 import { ZodCoercer } from '@orpc/zod'
 
-const openapiHandler = new OpenAPIServerlessHandler(router, {
+const app = express()
+
+const openAPIHandler = new OpenAPIServerlessHandler(router, {
   schemaCoercers: [
     new ZodCoercer(),
   ],
 })
+
 const orpcHandler = new ORPCHandler(router)
-const compositeHandler = new CompositeHandler([openapiHandler, orpcHandler])
 
-const app = express()
+app.use(expressAdapter([orpcHandler, openAPIHandler], {
+  prefix: '/api',
+}))
 
-app.all('/api/*', (req, res) => {
-  return compositeHandler.handle(req, res, {
-    context: {},
-    prefix: '/api',
-  })
+app.use((req, res, next) => {
+  res.status(404).send('Not Found')
 })
 
 app.listen(3000, () => {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -30,6 +30,11 @@
         "import": "./dist/node.js",
         "default": "./dist/node.js"
       },
+      "./express": {
+        "types": "./dist/src/adapters/express/index.d.ts",
+        "import": "./dist/express.js",
+        "default": "./dist/express.js"
+      },
       "./🔒/*": {
         "types": "./dist/src/*.d.ts"
       }
@@ -39,6 +44,7 @@
     ".": "./src/index.ts",
     "./fetch": "./src/adapters/fetch/index.ts",
     "./node": "./src/adapters/node/index.ts",
+    "./express": "./src/adapters/express/index.ts",
     "./🔒/*": {
       "types": "./src/*.ts"
     }
@@ -59,6 +65,7 @@
     "@orpc/shared": "workspace:*"
   },
   "devDependencies": {
+    "@types/express": "^5.0.0",
     "zod": "^3.24.1"
   }
 }

--- a/packages/server/src/adapters/express/composite-handler.ts
+++ b/packages/server/src/adapters/express/composite-handler.ts
@@ -1,0 +1,19 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import type { Context } from '../../types'
+import type { ConditionalRequestHandler, RequestHandler, RequestOptions } from './types'
+
+export class CompositeHandler<T extends Context> implements RequestHandler<T> {
+  constructor(
+    private readonly handlers: ConditionalRequestHandler<T>[],
+  ) {}
+
+  async handle(req: IncomingMessage, res: ServerResponse, ...opt: [options: RequestOptions<T>] | (undefined extends T ? [] : never)): Promise<void> {
+    for (const handler of this.handlers) {
+      if (handler.condition(req)) {
+        return handler.handle(req, res, ...opt)
+      }
+    }
+
+    res.statusCode = 404
+  }
+}

--- a/packages/server/src/adapters/express/composite-handler.ts
+++ b/packages/server/src/adapters/express/composite-handler.ts
@@ -8,7 +8,18 @@ export class CompositeHandler<T extends Context> implements RequestHandler<T> {
   ) {}
 
   async handle(req: IncomingMessage, res: ServerResponse, ...opt: [options: RequestOptions<T>] | (undefined extends T ? [] : never)): Promise<void> {
-    for (const handler of this.handlers) {
+    const len = this.handlers.length
+    const handlers = this.handlers
+
+    if (len > 0) {
+      const handler = handlers[0]!
+      if (handler.condition(req)) {
+        return handler.handle(req, res, ...opt)
+      }
+    }
+
+    for (let i = 1; i < len; i++) {
+      const handler = handlers[i]!
       if (handler.condition(req)) {
         return handler.handle(req, res, ...opt)
       }

--- a/packages/server/src/adapters/express/index.ts
+++ b/packages/server/src/adapters/express/index.ts
@@ -1,0 +1,3 @@
+export * from './composite-handler'
+export * from './middleware'
+export * from './types'

--- a/packages/server/src/adapters/express/middleware.ts
+++ b/packages/server/src/adapters/express/middleware.ts
@@ -1,0 +1,24 @@
+import type { ConditionalRequestHandler, RequestHandler, RequestOptions } from '@orpc/server/node'
+import type { NextFunction, Request, Response } from 'express'
+import type { Context } from '../../types'
+import { CompositeHandler } from '@orpc/server/node'
+
+export function expressAdapter<T extends Context>(
+  handlers: (ConditionalRequestHandler<T> | RequestHandler<T>)[],
+  options?: Partial<RequestOptions<T>>,
+) {
+  const compositeHandler = new CompositeHandler(handlers as ConditionalRequestHandler<T>[])
+
+  return (req: Request, res: Response, next: NextFunction) => {
+    try {
+      compositeHandler.handle(req, res, ...(options ? [options as RequestOptions<T>] : [undefined as any]))
+
+      if (res.statusCode === 404) {
+        next()
+      }
+    }
+    catch (error) {
+      next(error)
+    }
+  }
+}

--- a/packages/server/src/adapters/express/middleware.ts
+++ b/packages/server/src/adapters/express/middleware.ts
@@ -1,7 +1,7 @@
-import type { ConditionalRequestHandler, RequestHandler, RequestOptions } from '@orpc/server/node'
+import type { ConditionalRequestHandler, RequestHandler, RequestOptions } from '@orpc/server/express'
 import type { NextFunction, Request, Response } from 'express'
 import type { Context } from '../../types'
-import { CompositeHandler } from '@orpc/server/node'
+import { CompositeHandler } from '@orpc/server/express'
 
 export function expressAdapter<T extends Context>(
   handlers: (ConditionalRequestHandler<T> | RequestHandler<T>)[],
@@ -10,15 +10,13 @@ export function expressAdapter<T extends Context>(
   const compositeHandler = new CompositeHandler(handlers as ConditionalRequestHandler<T>[])
 
   return (req: Request, res: Response, next: NextFunction) => {
-    try {
-      compositeHandler.handle(req, res, ...(options ? [options as RequestOptions<T>] : [undefined as any]))
-
-      if (res.statusCode === 404) {
+    Promise.resolve()
+      .then(() =>
+        compositeHandler.handle(req, res, ...(options ? [options as RequestOptions<T>] : [undefined as any])),
+      )
+      .then(() => {
         next()
-      }
-    }
-    catch (error) {
-      next(error)
-    }
+      })
+      .catch(next)
   }
 }

--- a/packages/server/src/adapters/express/types.ts
+++ b/packages/server/src/adapters/express/types.ts
@@ -1,0 +1,24 @@
+/// <reference types="node" />
+
+import type { RequestOptions as BaseRequestOptions } from '@mjackson/node-fetch-server'
+import type { HTTPPath } from '@orpc/contract'
+import type { Promisable } from '@orpc/shared'
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import type { Context, WithSignal } from '../../types'
+
+export type RequestOptions<T extends Context> =
+  & BaseRequestOptions
+  & WithSignal
+  & { prefix?: HTTPPath }
+  & (undefined extends T ? { context?: T } : { context: T })
+  & {
+    beforeSend?: (response: Response, context: T) => Promisable<void>
+  }
+
+export interface RequestHandler<T extends Context> {
+  handle: (req: IncomingMessage, res: ServerResponse, ...opt: [options: RequestOptions<T>] | (undefined extends T ? [] : never)) => void
+}
+
+export interface ConditionalRequestHandler<T extends Context> extends RequestHandler<T> {
+  condition: (request: IncomingMessage) => boolean
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -331,6 +331,9 @@ importers:
         specifier: workspace:*
         version: link:../shared
     devDependencies:
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.0
       zod:
         specifier: ^3.24.1
         version: 3.24.1


### PR DESCRIPTION
I've added an express adapter that achieves the following:
- Let's express handle 404 errors as designed
- Simplifies instantiating the handler into 1 simple function while still allowing for all options to be passed 

This is a big step forward for using oRPC in express as it provides a clean dev syntax while bringing the logic more behind the adapter and ensuring it follows express' standards. No performance hits should be made as it is just a simple abstraction layer.