### PR TITLE
fix(zod): include array items schema in JSON schema output (#104)

### DIFF
--- a/packages/zod/src/converter.test.ts
+++ b/packages/zod/src/converter.test.ts
@@ -69,6 +69,7 @@ describe('array types', () => {
     const schema = z.array(z.string())
     expect(zodToJsonSchema(schema)).toEqual({
       type: 'array',
+      items: { type: 'string' },
     })
   })
 
@@ -76,6 +77,9 @@ describe('array types', () => {
     const schema = z.array(z.string()).min(1).max(5)
     expect(zodToJsonSchema(schema)).toEqual({
       type: 'array',
+      items: {
+        type: 'string',
+      },
       minItems: 1,
       maxItems: 5,
     })
@@ -268,12 +272,36 @@ describe('lazy types', () => {
       }),
     )
 
+    const tree1 = {
+      type: 'object',
+      properties: {
+        value: { type: 'string' },
+        children: {
+          type: 'array',
+          items: {},
+        },
+      },
+      required: ['value'],
+    }
+    const tree2 = {
+      type: 'object',
+      properties: {
+        value: { type: 'string' },
+        children: {
+          type: 'array',
+          items: tree1,
+        },
+      },
+      required: ['value'],
+    }
+
     expect(zodToJsonSchema(treeSchema, { maxLazyDepth: 2 })).toEqual({
       type: 'object',
       properties: {
         value: { type: 'string' },
         children: {
           type: 'array',
+          items: tree2,
         },
       },
       required: ['value'],

--- a/packages/zod/src/converter.ts
+++ b/packages/zod/src/converter.ts
@@ -364,6 +364,8 @@ export function zodToJsonSchema(
 
       const json: JSONSchema.JSONSchema = { type: 'array' }
 
+      json.items = zodToJsonSchema(def.type, childOptions)
+
       if (def.exactLength) {
         json.maxItems = def.exactLength.value
         json.minItems = def.exactLength.value


### PR DESCRIPTION
Found the relevant code and added this myself. Would like to help with issues like this where I can :)

Might be worth considering changing the test to not involve arrays (e.g. left/right instead of children, or a linked list instead of a tree), as it seems to be testing two features (lazy + arrays). The original test wasn't actually testing the lazy functionality as the converter wouldn't recurse into the array.

Fixes #102 