### PR TITLE
feat(openapi): add default values to generated openapi

### DIFF
--- a/packages/zod/src/converter.test.ts
+++ b/packages/zod/src/converter.test.ts
@@ -67,7 +67,13 @@ describe('primitive types', () => {
 describe('default values', () => {
   it('should add the default property', () => {
     const schema = z.string().default('test')
-    expect(zodToJsonSchema(schema)).toEqual({ type: 'string', default: 'test' })
+    expect(zodToJsonSchema(schema)).toEqual({
+      anyOf: [
+        { const: 'undefined' },
+        { type: 'string', default: 'test' },
+      ],
+      default: 'test',
+    })
   })
 
   it('should be skipped in outputs', () => {

--- a/packages/zod/src/converter.test.ts
+++ b/packages/zod/src/converter.test.ts
@@ -82,15 +82,23 @@ describe('default values', () => {
       .max(10)
       .email()
       .regex(/^[a-z]+$/)
-      .default('testlong')
+      .default('test')
 
     expect(zodToJsonSchema(schema)).toEqual({
-      type: 'string',
-      minLength: 5,
-      maxLength: 10,
-      format: Format.Email,
-      pattern: '^[a-z]+$',
-      default: 'testlong',
+      anyOf: [
+        { const: 'undefined' },
+        {
+          type: 'string',
+          minLength: 5,
+          maxLength: 10,
+          format: Format.Email,
+          pattern: '^[a-z]+$',
+          // This is the resulting schema twice since, simiarly to ZodOptional,
+          // it is valid either in an object or in the anyOf.
+          default: 'test',
+        },
+      ],
+      default: 'test',
     })
   })
 })

--- a/packages/zod/src/converter.test.ts
+++ b/packages/zod/src/converter.test.ts
@@ -64,6 +64,37 @@ describe('primitive types', () => {
   })
 })
 
+describe('default values', () => {
+  it('should add the default property', () => {
+    const schema = z.string().default('test')
+    expect(zodToJsonSchema(schema)).toEqual({ type: 'string', default: 'test' })
+  })
+
+  it('should be skipped in outputs', () => {
+    const schema = z.string().default('test')
+    expect(zodToJsonSchema(schema, { mode: 'output' })).toEqual({ type: 'string' })
+  })
+
+  it('should not affect other constraints or properties', () => {
+    const schema = z
+      .string()
+      .min(5)
+      .max(10)
+      .email()
+      .regex(/^[a-z]+$/)
+      .default('testlong')
+
+    expect(zodToJsonSchema(schema)).toEqual({
+      type: 'string',
+      minLength: 5,
+      maxLength: 10,
+      format: Format.Email,
+      pattern: '^[a-z]+$',
+      default: 'testlong',
+    })
+  })
+})
+
 describe('array types', () => {
   it('should convert array schema', () => {
     const schema = z.array(z.string())

--- a/packages/zod/src/converter.ts
+++ b/packages/zod/src/converter.ts
@@ -564,7 +564,11 @@ export function zodToJsonSchema(
 
     case ZodFirstPartyTypeKind.ZodDefault: {
       const schema_ = schema__ as ZodDefault<ZodTypeAny>
-      return zodToJsonSchema(schema_._def.innerType, childOptions)
+      const inner = zodToJsonSchema(schema_._def.innerType, childOptions)
+      if (childOptions.mode === 'output') {
+        return inner
+      }
+      return { ...inner, default: schema_._def.defaultValue() }
     }
 
     case ZodFirstPartyTypeKind.ZodEffects: {

--- a/packages/zod/src/converter.ts
+++ b/packages/zod/src/converter.ts
@@ -568,7 +568,11 @@ export function zodToJsonSchema(
       if (childOptions.mode === 'output') {
         return inner
       }
-      return { ...inner, default: schema_._def.defaultValue() }
+
+      return {
+        anyOf: [UNDEFINED_JSON_SCHEMA, { ...inner, default: schema_._def.defaultValue() }],
+        default: schema_._def.defaultValue(),
+      }
     }
 
     case ZodFirstPartyTypeKind.ZodEffects: {


### PR DESCRIPTION
Fixes #103 by adding the `default` property to generated JSON schema.

I've opted to have it omitted in output schemas, since those defaults will be filled in when the output schema is run.