### PR TITLE
docs(nuxt): Use H3 utilities

### DIFF
--- a/apps/content/docs/integrations/nuxt.md
+++ b/apps/content/docs/integrations/nuxt.md
@@ -30,8 +30,8 @@ export default defineEventHandler(async (event) => {
     return
   }
 
-  event.node.res.statusCode = 404
-  event.node.res.end('Not found')
+  setResponseStatus(event, 404, 'Not Found')
+  return 'Not found'
 })
 ```
 

--- a/playgrounds/nuxt/server/routes/api/[...].ts
+++ b/playgrounds/nuxt/server/routes/api/[...].ts
@@ -15,7 +15,8 @@ const openAPIHandler = new OpenAPIHandler(router, {
 })
 
 export default defineEventHandler(async (event) => {
-  const context = event.node.req.headers.authorization
+  const authorization = getHeader(event, 'authorization')
+  const context = authorization
     ? { user: { id: 'test', name: 'John Doe', email: 'john@doe.com' } }
     : {}
 
@@ -28,6 +29,6 @@ export default defineEventHandler(async (event) => {
     return
   }
 
-  event.node.res.statusCode = 404
-  event.node.res.end('Not found')
+  setResponseStatus(event, 404, 'Not Found')
+  return 'Not Found'
 })

--- a/playgrounds/nuxt/server/routes/rpc/[...].ts
+++ b/playgrounds/nuxt/server/routes/rpc/[...].ts
@@ -11,7 +11,8 @@ const rpcHandler = new RPCHandler(router, {
 })
 
 export default defineEventHandler(async (event) => {
-  const context = event.node.req.headers.authorization
+  const authorization = getHeader(event, 'authorization')
+  const context = authorization
     ? { user: { id: 'test', name: 'John Doe', email: 'john@doe.com' } }
     : {}
 
@@ -24,6 +25,6 @@ export default defineEventHandler(async (event) => {
     return
   }
 
-  event.node.res.statusCode = 404
-  event.node.res.end('Not found')
+  setResponseStatus(event, 404, 'Not Found')
+  return 'Not Found'
 })

--- a/playgrounds/nuxt/server/routes/scalar.ts
+++ b/playgrounds/nuxt/server/routes/scalar.ts
@@ -32,6 +32,6 @@ export default defineEventHandler(async (event) => {
       </html>
     `
 
-  event.node.res.setHeader('Content-Type', 'text/html')
-  event.node.res.end(html)
+  setResponseHeader(event, 'content-type', 'text/html')
+  return html
 })


### PR DESCRIPTION
Just a small PR replacing direct response manipulation with H3's utils 🫡 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized error handling for unmatched routes by implementing a unified approach for setting response statuses.
  - Improved header management by adopting a consistent method for retrieving authorization details.
  - Adjusted the flow for HTML responses to return content directly instead of explicitly ending responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->