### PR TITLE
docs: improve comparison for tRPC

### DIFF
--- a/apps/content/docs/comparison.md
+++ b/apps/content/docs/comparison.md
@@ -14,8 +14,8 @@ This comparison table helps you understand how oRPC differs from other popular T
 | Feature                                  | oRPC | tRPC | ts-rest |
 | ---------------------------------------- | ---- | ---- | ------- |
 | End-to-end Input/Output Typesafe         | ✅   | ✅   | ✅      |
-| End-to-end Errors Typesafe               | ✅   | ✅   | ✅      |
-| End-to-end File/Blob Typesafe            | ✅   | ✅   | 🛑      |
+| End-to-end Errors Typesafe               | ✅   | 🟡   | ✅      |
+| End-to-end File/Blob Typesafe            | ✅   | 🟡   | 🛑      |
 | End-to-end Streaming Typesafe            | ✅   | ✅   | 🛑      |
 | Tanstack Query Integration (React)       | ✅   | ✅   | 🟡      |
 | Tanstack Query Integration (Vue)         | ✅   | 🛑   | 🟡      |

--- a/apps/content/docs/comparison.md
+++ b/apps/content/docs/comparison.md
@@ -14,8 +14,8 @@ This comparison table helps you understand how oRPC differs from other popular T
 | Feature                                  | oRPC | tRPC | ts-rest |
 | ---------------------------------------- | ---- | ---- | ------- |
 | End-to-end Input/Output Typesafe         | ✅   | ✅   | ✅      |
-| End-to-end Errors Typesafe               | ✅   | 🛑   | ✅      |
-| End-to-end File/Blob Typesafe            | ✅   | 🛑   | 🛑      |
+| End-to-end Errors Typesafe               | ✅   | ✅   | ✅      |
+| End-to-end File/Blob Typesafe            | ✅   | ✅   | 🛑      |
 | End-to-end Streaming Typesafe            | ✅   | ✅   | 🛑      |
 | Tanstack Query Integration (React)       | ✅   | ✅   | 🟡      |
 | Tanstack Query Integration (Vue)         | ✅   | 🛑   | 🟡      |
@@ -25,14 +25,14 @@ This comparison table helps you understand how oRPC differs from other popular T
 | With Contract-First Approach             | ✅   | 🛑   | ✅      |
 | Without Contract-First Approach          | ✅   | ✅   | 🛑      |
 | OpenAPI Support                          | ✅   | 🟡   | 🟡      |
-| Server Actions Support                   | ✅   | 🟡   | 🛑      |
-| Lazy Router                              | ✅   | 🛑   | 🛑      |
-| Native Types (Date, URL, Set, Maps, ...) | ✅   | 🟡   | 🛑      |
+| Server Actions Support                   | ✅   | ✅   | 🛑      |
+| Lazy Router                              | ✅   | ✅   | 🛑      |
+| Native Types (Date, URL, Set, Maps, ...) | ✅   | ✅   | 🛑      |
 | Streaming response (SSE)                 | ✅   | ✅   | 🛑      |
 | Standard Schema                          | ✅   | ✅   | 🛑      |
-| Plugins-able (CORS, ...)                 | ✅   | 🛑   | 🛑      |
-| Dedicated Zod Schemas                    | ✅   | 🛑   | 🛑      |
-| Use Native Modules on each runtime       | ✅   | 🟡   | 🟡      |
+| Plugins-able (CORS, ...)                 | ✅   | ✅   | 🛑      |
+| Dedicated Zod Schemas                    | ✅   | N/A   | 🛑      |
+| Use Native Modules on each runtime       | ✅   | ✅   | 🟡      |
 | Batch Request                            | 🛑   | ✅   | 🛑      |
 | WebSockets                               | 🛑   | ✅   | 🛑      |
 | Nest.js integration                      | 🛑   | 🟡   | ✅      |

--- a/apps/content/docs/comparison.md
+++ b/apps/content/docs/comparison.md
@@ -31,7 +31,7 @@ This comparison table helps you understand how oRPC differs from other popular T
 | Streaming response (SSE)                 | ✅   | ✅   | 🛑      |
 | Standard Schema                          | ✅   | ✅   | 🛑      |
 | Plugins-able (CORS, ...)                 | ✅   | ✅   | 🛑      |
-| Dedicated Zod Schemas                    | ✅   | N/A   | 🛑      |
+| Dedicated Zod Schemas                    | ✅   | N/A  | 🛑      |
 | Use Native Modules on each runtime       | ✅   | ✅   | 🟡      |
 | Batch Request                            | 🛑   | ✅   | 🛑      |
 | WebSockets                               | 🛑   | ✅   | 🛑      |


### PR DESCRIPTION
Updated comparison table to more accurately reflect what tRPC can do. 

Right now it makes an assumption that being coupled in several areas leads to tRPC being worse in those areas, whereas tRPC does provide out the box support but allows you to choose the library (ie. for transformers, cors) you use. 

tRPC is mounted inside an adapter which may be a native http module or an adapter inside of express or many other web servers, this means CORS is natively supported but at the adapter level rather than trying to handle that itself

Things like Lazy routers are actually more recent additions so this is a timely update there :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
	- Updated the support table to reflect improved feature support for tRPC. Now, several functionalities such as end-to-end error typesafety, file/blob typesafety, server actions, lazy routing, native types support, and plugin integration are marked as supported.
	- Adjusted the status for dedicated schemas to indicate they are not applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->