### PR TITLE
docs: tanstack start fix link to Nitro

### DIFF
--- a/apps/content/docs/integrations/tanstack-start.md
+++ b/apps/content/docs/integrations/tanstack-start.md
@@ -5,7 +5,7 @@ description: Integrate oRPC with TanStack Start
 
 # TanStack Start Integration
 
-[TanStack Start](https://tanstack.com/start) is a full-stack React framework built on [Nitro](https://nitro.dev/) and the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API). For additional context, see the [Fetch Server Integration](/docs/integrations/fetch-server) guide.
+[TanStack Start](https://tanstack.com/start) is a full-stack React framework built on [Nitro](https://nitro.build/) and the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API). For additional context, see the [Fetch Server Integration](/docs/integrations/fetch-server) guide.
 
 ## Server
 


### PR DESCRIPTION
This was just a mixed-up link, [nitro.dev](https://nitro.dev/) is an unrelated startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the TanStack Start documentation to reflect the correct Nitro URL, ensuring accurate reference information for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->