### PR TITLE
docs: remove undefined `createMiddleware` in Hono integration

### DIFF
--- a/apps/content/docs/integrations/hono.md
+++ b/apps/content/docs/integrations/hono.md
@@ -11,7 +11,7 @@ description: Integrate oRPC with Hono
 
 ```ts
 import { Hono } from 'hono'
-import { createMiddleware, RPCHandler } from '@orpc/server/fetch'
+import { RPCHandler } from '@orpc/server/fetch'
 
 const app = new Hono()
 


### PR DESCRIPTION
Removes the unused (and also undefined) `createMiddleware` function from the Hono integration docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the integration guide’s code example for clearer, up-to-date usage instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->