### PR TITLE
docs: add an example for fastify integration

### DIFF
--- a/apps/content/.vitepress/config.ts
+++ b/apps/content/.vitepress/config.ts
@@ -96,6 +96,7 @@ export default defineConfig({
           collapsed: true,
           items: [
             { text: 'Express', link: '/docs/integrations/express' },
+            { text: 'Fastify', link: '/docs/integrations/fastify' },
             { text: 'Next.js', link: '/docs/integrations/nextjs' },
             { text: 'Nuxt', link: '/docs/integrations/nuxt' },
             { text: 'Hono', link: '/docs/integrations/hono' },

--- a/apps/content/docs/integrations/fastify.md
+++ b/apps/content/docs/integrations/fastify.md
@@ -1,0 +1,53 @@
+---
+title: Fastify Integration
+description: Seamlessly integrate oRPC with Fastify
+---
+
+# Fastify Integration
+
+[Fastify](https://fastify.dev/) is a web framework highly focused on providing the best developer experience with the least overhead and a powerful plugin architecture. For additional context, refer to the [HTTP Adapter](/docs/adapters/http) guide.
+
+::: warning
+Fastify automatically parses the request payload which interferes with oRPC, that apply its own parser. To avoid errors, it's necessary to create a node http server and pass the requests to oRPC first, and if there's no match, pass it to Fastify.
+:::
+
+## Basic
+
+```ts
+import { createServer } from 'node:http'
+import Fastify from 'fastify'
+import { RPCHandler } from '@orpc/server/node'
+
+const handler = new RPCHandler(router)
+
+const fastify = Fastify({
+  logger: true,
+  serverFactory: (serverHandler) => {
+    const server = createServer(async (req, res) => {
+      const { matched } = await handler.handle(req, res, {
+        context: {},
+        prefix: "/api",
+      })
+
+      if (matched) {
+        return
+      }
+
+      serverHandler(req, res)
+    })
+
+    return server
+  },
+})
+
+try {
+  await fastify.listen({ port: 3000 })
+} catch (err) {
+  fastify.log.error(err)
+  process.exit(1)
+}
+```
+
+::: info
+The `handler` can be any supported oRPC handler, such as [RPCHandler](/docs/rpc-handler), [OpenAPIHandler](/docs/openapi/openapi-handler), or another custom handler.
+:::

--- a/apps/content/docs/integrations/fastify.md
+++ b/apps/content/docs/integrations/fastify.md
@@ -17,23 +17,28 @@ Fastify automatically parses the request payload which interferes with oRPC, tha
 import { createServer } from 'node:http'
 import Fastify from 'fastify'
 import { RPCHandler } from '@orpc/server/node'
+import { CORSPlugin } from '@orpc/server/plugins'
 
-const handler = new RPCHandler(router)
+const handler = new RPCHandler(router, {
+  plugins: [
+    new CORSPlugin()
+  ]
+})
 
 const fastify = Fastify({
   logger: true,
-  serverFactory: (serverHandler) => {
+  serverFactory: (fastifyHandler) => {
     const server = createServer(async (req, res) => {
       const { matched } = await handler.handle(req, res, {
         context: {},
-        prefix: "/api",
+        prefix: '/rpc',
       })
 
       if (matched) {
         return
       }
 
-      serverHandler(req, res)
+      fastifyHandler(req, res)
     })
 
     return server
@@ -42,7 +47,8 @@ const fastify = Fastify({
 
 try {
   await fastify.listen({ port: 3000 })
-} catch (err) {
+}
+catch (err) {
   fastify.log.error(err)
   process.exit(1)
 }


### PR DESCRIPTION
This adds some information to integrate oRPC with Fastify in case anyone (including me) didn't know how to do that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new guide on integrating oRPC with Fastify, including examples for custom server setup, request delegation, and error handling.
  - Updated the documentation sidebar to include the Fastify integration guide for easier navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->