### PR TITLE
feat: improve TypeScript go to definition navigation

### DIFF
--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -23,9 +23,9 @@ export type ClientRest<TClientContext extends ClientContext, TInput> = Record<ne
 
 export type ClientPromiseResult<TOutput, TError> = PromiseWithError<TOutput, TError>
 
-export interface Client<TClientContext extends ClientContext, TInput, TOutput, TError> {
-  (...rest: ClientRest<TClientContext, TInput>): ClientPromiseResult<TOutput, TError>
-}
+export type Client<TClientContext extends ClientContext, TInput, TOutput, TError> = (
+  ...rest: ClientRest<TClientContext, TInput>
+) => ClientPromiseResult<TOutput, TError>
 
 export type NestedClient<TClientContext extends ClientContext> = Client<TClientContext, any, any, any> | {
   [k: string]: NestedClient<TClientContext>


### PR DESCRIPTION
## Problem
Previously, when using cmd/ctrl+click on procedure names in client-side code (like `orpc.planet.list`), TypeScript's "Go to Definition" feature would:
- Present multiple ambiguous suggestions requiring manual selection
- Often navigate to router definitions instead of actual implementation files

This created friction when trying to navigate between client and server code during development.

## Solution
Changed the `Client` type from an interface with a call signature:
```typescript
export interface Client<TClientContext extends ClientContext, TInput, TOutput, TError> {
  (...rest: ClientRest<TClientContext, TInput>): ClientPromiseResult<TOutput, TError>
}
```

To a direct function type:
```typescript
export type Client<TClientContext extends ClientContext, TInput, TOutput, TError> = (
  ...rest: ClientRest<TClientContext, TInput>
) => ClientPromiseResult<TOutput, TError>
```

## Technical Explanation
This change improves TypeScript's IDE navigation because:
- TypeScript's language server handles direct function types more precisely than interface call signatures
- The explicit function type creates clearer reference paths for the TypeScript compiler to follow
- This eliminates the ambiguity that was causing multiple suggestions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the internal type declaration for improved consistency. No impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->