### PR TITLE
feat: support `skipToken` as query input

### DIFF
--- a/packages/vue-query/src/procedure-utils.test.ts
+++ b/packages/vue-query/src/procedure-utils.test.ts
@@ -1,3 +1,4 @@
+import { skipToken } from '@tanstack/vue-query'
 import { computed, ref } from 'vue'
 import * as Key from './key'
 import { createProcedureUtils } from './procedure-utils'
@@ -25,9 +26,12 @@ describe('createProcedureUtils', () => {
     expect(buildKeySpy).toHaveBeenCalledTimes(1)
     expect(buildKeySpy).toHaveBeenCalledWith(['ping'], { type: 'query', input: { search: '__search__' } })
 
-    await expect(options.queryFn!({ signal } as any)).resolves.toEqual('__output__')
+    await expect(options.queryFn.value!({ signal } as any)).resolves.toEqual('__output__')
     expect(client).toHaveBeenCalledTimes(1)
     expect(client).toBeCalledWith({ search: '__search__' }, { signal, context: { batch: '__batch__' } })
+
+    const optionsWithSkipToken = utils.queryOptions({ input: computed(() => skipToken), context: { batch: '__batch__' } })
+    expect(optionsWithSkipToken.queryFn.value).toBe(skipToken)
   })
 
   it('.infiniteOptions', async () => {

--- a/packages/vue-query/src/types.ts
+++ b/packages/vue-query/src/types.ts
@@ -16,7 +16,7 @@ export type MaybeRefDeep<T> = MaybeRef<
 >
 
 export type QueryOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TSelectData> =
-  & (undefined extends TInput ? { input?: MaybeRefDeep<TInput | SkipToken> } : { input: MaybeRefDeep<TInput | SkipToken> })
+  & (undefined extends TInput ? { input?: MaybeRefDeep<TInput> } : { input: MaybeRefDeep<TInput> })
   & (Record<never, never> extends TClientContext ? { context?: MaybeRefDeep<TClientContext> } : { context: MaybeRefDeep<TClientContext> })
   & {
     [P in keyof Omit<QueryObserverOptions<TOutput, TError, TSelectData, TOutput>, 'queryKey' | 'enabled'>]:
@@ -30,7 +30,26 @@ export type QueryOptionsIn<TClientContext extends ClientContext, TInput, TOutput
 
 export interface QueryOptionsBase<TOutput, TError> {
   queryKey: ComputedRef<QueryKey>
-  queryFn: ComputedRef<(ctx: QueryFunctionContext) => Promise<TOutput>>
+  queryFn: (ctx: QueryFunctionContext) => Promise<TOutput>
+  retry?(failureCount: number, error: TError): boolean // this help tanstack can infer TError
+}
+
+export type SkippableQueryOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TSelectData> =
+  & (undefined extends TInput ? { input?: MaybeRefDeep<TInput | SkipToken> } : { input: MaybeRefDeep<TInput | SkipToken> })
+  & (Record<never, never> extends TClientContext ? { context?: MaybeRefDeep<TClientContext> } : { context: MaybeRefDeep<TClientContext> })
+  & {
+    [P in keyof Omit<QueryObserverOptions<TOutput, TError, TSelectData, TOutput>, 'queryKey' | 'enabled'>]:
+    MaybeRefDeep<QueryObserverOptions<TOutput, TError, TSelectData, TOutput>[P]>
+  }
+  & {
+    enabled?: MaybeRefOrGetter<QueryObserverOptions<TOutput, TError, TSelectData, TOutput>['enabled']>
+    queryKey?: MaybeRefDeep<QueryObserverOptions<TOutput, TError, TSelectData, TOutput>['queryKey']>
+    shallow?: boolean
+  }
+
+export interface SkippableQueryOptionsBase<TOutput, TError> {
+  queryKey: ComputedRef<QueryKey>
+  queryFn: ComputedRef<((ctx: QueryFunctionContext) => Promise<TOutput>) | SkipToken>
   retry?(failureCount: number, error: TError): boolean // this help tanstack can infer TError
 }
 

--- a/packages/vue-query/src/types.ts
+++ b/packages/vue-query/src/types.ts
@@ -1,6 +1,6 @@
 import type { ClientContext } from '@orpc/client'
 import type { AnyFunction } from '@orpc/shared'
-import type { InfiniteQueryObserverOptions, MutationObserverOptions, QueryFunctionContext, QueryKey, QueryObserverOptions } from '@tanstack/vue-query'
+import type { InfiniteQueryObserverOptions, MutationObserverOptions, QueryFunctionContext, QueryKey, QueryObserverOptions, SkipToken } from '@tanstack/vue-query'
 import type { ComputedRef, MaybeRef, MaybeRefOrGetter } from 'vue'
 
 /**
@@ -16,7 +16,7 @@ export type MaybeRefDeep<T> = MaybeRef<
 >
 
 export type QueryOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TSelectData> =
-  & (undefined extends TInput ? { input?: MaybeRefDeep<TInput> } : { input: MaybeRefDeep<TInput> })
+  & (undefined extends TInput ? { input?: MaybeRefDeep<TInput | SkipToken> } : { input: MaybeRefDeep<TInput | SkipToken> })
   & (Record<never, never> extends TClientContext ? { context?: MaybeRefDeep<TClientContext> } : { context: MaybeRefDeep<TClientContext> })
   & {
     [P in keyof Omit<QueryObserverOptions<TOutput, TError, TSelectData, TOutput>, 'queryKey' | 'enabled'>]:
@@ -30,7 +30,7 @@ export type QueryOptionsIn<TClientContext extends ClientContext, TInput, TOutput
 
 export interface QueryOptionsBase<TOutput, TError> {
   queryKey: ComputedRef<QueryKey>
-  queryFn(ctx: QueryFunctionContext): Promise<TOutput>
+  queryFn: ComputedRef<(ctx: QueryFunctionContext) => Promise<TOutput>>
   retry?(failureCount: number, error: TError): boolean // this help tanstack can infer TError
 }
 


### PR DESCRIPTION
Closes #495 

This PR adds support for passing `skipToken` to `@tanstack/x-query` client calls.

TODOs:
- [ ] docs
- [ ] react + tests
- [ ] solid + tests
- [ ] svelte + tests
- [x] vue + tests