### PR TITLE
feat(arktype): support ToJsonSchema.Options in ArkTypeToJsonSchemaConverter

### DIFF
--- a/packages/arktype/package.json
+++ b/packages/arktype/package.json
@@ -34,6 +34,7 @@
     "type:check": "tsc -b"
   },
   "peerDependencies": {
+    "@ark/schema": "*",
     "@orpc/contract": "workspace:*",
     "@orpc/server": "workspace:*",
     "arktype": "*"

--- a/packages/arktype/package.json
+++ b/packages/arktype/package.json
@@ -36,7 +36,6 @@
   "peerDependencies": {
     "@ark/schema": "*",
     "@orpc/contract": "workspace:*",
-    "@orpc/server": "workspace:*",
     "arktype": "*"
   },
   "dependencies": {

--- a/packages/arktype/src/converter.test.ts
+++ b/packages/arktype/src/converter.test.ts
@@ -3,7 +3,14 @@ import { z } from 'zod'
 import { experimental_ArkTypeToJsonSchemaConverter as ArkTypeToJsonSchemaConverter } from './converter'
 
 it('arkTypeToJsonSchemaConverter.convert', async () => {
-  const converter = new ArkTypeToJsonSchemaConverter()
+  const converter = new ArkTypeToJsonSchemaConverter({
+    fallback: {
+      default: () => ({
+        'type': 'null',
+        'x-type': 'null',
+      }),
+    },
+  })
 
   expect(converter.convert(type('string'), { strategy: 'input' })).toEqual(
     [true, {
@@ -11,6 +18,7 @@ it('arkTypeToJsonSchemaConverter.convert', async () => {
       type: 'string',
     }],
   )
+
   expect(converter.convert(type({ a: 'string' }), { strategy: 'input' })).toEqual(
     [true, {
       $schema: 'https://json-schema.org/draft/2020-12/schema',
@@ -19,11 +27,20 @@ it('arkTypeToJsonSchemaConverter.convert', async () => {
       required: ['a'],
     }],
   )
+
   expect(converter.convert(type('Date'), { strategy: 'input' })).toEqual(
     [true, {
       $schema: 'https://json-schema.org/draft/2020-12/schema',
       format: 'date-time',
       type: 'string',
+    }],
+  )
+
+  expect(converter.convert(type('Error'), { strategy: 'input' })).toEqual(
+    [true, {
+      '$schema': 'https://json-schema.org/draft/2020-12/schema',
+      'type': 'null',
+      'x-type': 'null',
     }],
   )
 })

--- a/packages/arktype/src/converter.test.ts
+++ b/packages/arktype/src/converter.test.ts
@@ -3,7 +3,12 @@ import { z } from 'zod'
 import { experimental_ArkTypeToJsonSchemaConverter as ArkTypeToJsonSchemaConverter } from './converter'
 
 it('arkTypeToJsonSchemaConverter.convert', async () => {
-  const converter = new ArkTypeToJsonSchemaConverter()
+  const converter = new ArkTypeToJsonSchemaConverter({
+    fallback: {
+      default: ctx => ctx.base,
+      date: ctx => ({ ...ctx.base, type: 'string', format: 'date-time' }),
+    },
+  })
 
   expect(converter.convert(type('string'), { strategy: 'input' })).toEqual(
     [true, {
@@ -17,6 +22,13 @@ it('arkTypeToJsonSchemaConverter.convert', async () => {
       type: 'object',
       properties: { a: { type: 'string' } },
       required: ['a'],
+    }],
+  )
+  expect(converter.convert(type('Date'), { strategy: 'input' })).toEqual(
+    [true, {
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      format: 'date-time',
+      type: 'string',
     }],
   )
 })

--- a/packages/arktype/src/converter.test.ts
+++ b/packages/arktype/src/converter.test.ts
@@ -3,12 +3,7 @@ import { z } from 'zod'
 import { experimental_ArkTypeToJsonSchemaConverter as ArkTypeToJsonSchemaConverter } from './converter'
 
 it('arkTypeToJsonSchemaConverter.convert', async () => {
-  const converter = new ArkTypeToJsonSchemaConverter({
-    fallback: {
-      default: ctx => ctx.base,
-      date: ctx => ({ ...ctx.base, type: 'string', format: 'date-time' }),
-    },
-  })
+  const converter = new ArkTypeToJsonSchemaConverter()
 
   expect(converter.convert(type('string'), { strategy: 'input' })).toEqual(
     [true, {

--- a/packages/arktype/src/converter.ts
+++ b/packages/arktype/src/converter.ts
@@ -3,11 +3,25 @@ import type { AnySchema } from '@orpc/contract'
 import type { ConditionalSchemaConverter, JSONSchema, SchemaConvertOptions } from '@orpc/openapi'
 import type { Type } from 'arktype'
 
+const defaultFallbacks: ToJsonSchema.FallbackOption = {
+  date: ctx => ({
+    ...ctx.base,
+    type: 'string',
+    format: 'date-time',
+  }),
+}
+
 export class experimental_ArkTypeToJsonSchemaConverter implements ConditionalSchemaConverter {
   options: ToJsonSchema.Options | undefined
 
   constructor(_options?: ToJsonSchema.Options) {
-    this.options = _options
+    this.options = {
+      ..._options,
+      fallback: {
+        ...defaultFallbacks,
+        ..._options?.fallback,
+      },
+    }
   }
 
   condition(schema: AnySchema | undefined): boolean {

--- a/packages/arktype/src/converter.ts
+++ b/packages/arktype/src/converter.ts
@@ -2,24 +2,25 @@ import type { ToJsonSchema } from '@ark/schema'
 import type { AnySchema } from '@orpc/contract'
 import type { ConditionalSchemaConverter, JSONSchema, SchemaConvertOptions } from '@orpc/openapi'
 import type { Type } from 'arktype'
+import { JSONSchemaFormat } from '@orpc/openapi'
 
-const defaultFallbacks: ToJsonSchema.FallbackOption = {
+const defaultToJsonSchemaFallback: ToJsonSchema.FallbackOption = {
   date: ctx => ({
     ...ctx.base,
     type: 'string',
-    format: 'date-time',
+    format: JSONSchemaFormat.DateTime,
   }),
 }
 
 export class experimental_ArkTypeToJsonSchemaConverter implements ConditionalSchemaConverter {
-  options: ToJsonSchema.Options | undefined
+  #options: ToJsonSchema.Options
 
-  constructor(_options?: ToJsonSchema.Options) {
-    this.options = {
-      ..._options,
+  constructor(options: ToJsonSchema.Options = {}) {
+    this.#options = {
+      ...options,
       fallback: {
-        ...defaultFallbacks,
-        ..._options?.fallback,
+        ...defaultToJsonSchemaFallback,
+        ...options?.fallback,
       },
     }
   }
@@ -29,7 +30,7 @@ export class experimental_ArkTypeToJsonSchemaConverter implements ConditionalSch
   }
 
   convert(schema: AnySchema | undefined, _options: SchemaConvertOptions): [required: boolean, jsonSchema: Exclude<JSONSchema, boolean>] {
-    const jsonSchema = (schema as Type).toJsonSchema(this.options)
+    const jsonSchema = (schema as Type).toJsonSchema(this.#options)
 
     return [true, jsonSchema]
   }

--- a/packages/arktype/src/converter.ts
+++ b/packages/arktype/src/converter.ts
@@ -1,14 +1,21 @@
+import type { ToJsonSchema } from '@ark/schema'
 import type { AnySchema } from '@orpc/contract'
 import type { ConditionalSchemaConverter, JSONSchema, SchemaConvertOptions } from '@orpc/openapi'
 import type { Type } from 'arktype'
 
 export class experimental_ArkTypeToJsonSchemaConverter implements ConditionalSchemaConverter {
+  options: ToJsonSchema.Options | undefined
+
+  constructor(_options?: ToJsonSchema.Options) {
+    this.options = _options
+  }
+
   condition(schema: AnySchema | undefined): boolean {
     return schema !== undefined && schema['~standard'].vendor === 'arktype'
   }
 
   convert(schema: AnySchema | undefined, _options: SchemaConvertOptions): [required: boolean, jsonSchema: Exclude<JSONSchema, boolean>] {
-    const jsonSchema = (schema as Type).toJsonSchema()
+    const jsonSchema = (schema as Type).toJsonSchema(this.options)
 
     return [true, jsonSchema]
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,9 @@ importers:
 
   packages/arktype:
     dependencies:
+      '@ark/schema':
+        specifier: '*'
+        version: 0.46.0
       '@orpc/contract':
         specifier: workspace:*
         version: link:../contract

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,9 +173,6 @@ importers:
       '@orpc/openapi':
         specifier: workspace:*
         version: link:../openapi
-      '@orpc/server':
-        specifier: workspace:*
-        version: link:../server
       arktype:
         specifier: '*'
         version: 2.1.20


### PR DESCRIPTION
Issue: `ArkTypeToJsonSchemaConverter` throws on some types like Dates

this PR adds a `options` arg to configure fallback json schemas
https://arktype.io/docs/configuration#tojsonschema

```ts
const generator = new OpenAPIGenerator({
  schemaConverters: [
    new ArkTypeToJsonSchemaConverter({
      fallback: {
        default: (ctx) => ctx.base,
        date: (ctx) => ({ ...ctx.base, type: "string", format: "date-time" }),
      },
    }),
  ],
});
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring JSON schema conversion with custom options, including handling of date types as strings with date-time format.
- **Tests**
  - Updated and expanded tests to verify correct schema generation for date types and fallback behavior.
- **Chores**
  - Updated peer dependencies by adding "@ark/schema" and removing "@orpc/server".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->