### PR TITLE
docs: deal with body already used error in "Elysia Adapter"

### DIFF
--- a/apps/content/docs/adapters/elysia.md
+++ b/apps/content/docs/adapters/elysia.md
@@ -23,7 +23,7 @@ const app = new Elysia()
 
     return response ?? new Response('Not Found', { status: 404 })
   }, {
-    parse: 'none' // Disable Elysia's body parser; oRPC handler needs raw body access, pre-parsing consumes it (bodyUsed=true).
+    parse: 'none' // Disable Elysia body parser to prevent "body already used" error
   })
   .listen(3000)
 

--- a/apps/content/docs/adapters/elysia.md
+++ b/apps/content/docs/adapters/elysia.md
@@ -23,7 +23,7 @@ const app = new Elysia()
 
     return response ?? new Response('Not Found', { status: 404 })
   }, {
-    parse: 'none' // disables the body parser so bodyUsed remains false.
+    parse: 'none' // Disable Elysia's body parser; oRPC handler needs raw body access, pre-parsing consumes it (bodyUsed=true).
   })
   .listen(3000)
 

--- a/apps/content/docs/adapters/elysia.md
+++ b/apps/content/docs/adapters/elysia.md
@@ -22,6 +22,8 @@ const app = new Elysia()
     })
 
     return response ?? new Response('Not Found', { status: 404 })
+  }, {
+    parse: 'none' // disables the body parser so bodyUsed remains false.
   })
   .listen(3000)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to clarify the use of the `parse: 'none'` option in the Elysia app setup, explaining its effect on request handling for the `/rpc*` route.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->