### PR TITLE
feat(zod): place null at the end when converting ZodNullable

### DIFF
--- a/packages/zod/src/converter.test.ts
+++ b/packages/zod/src/converter.test.ts
@@ -286,7 +286,7 @@ const processedCases: SchemaTestCase[] = [
   },
   {
     schema: z.string().nullable(),
-    input: [true, { anyOf: [{ type: 'null' }, { type: 'string' }] }],
+    input: [true, { anyOf: [{ type: 'string' }, { type: 'null' }] }],
     ignoreZodToJsonSchema: true,
   },
   {

--- a/packages/zod/src/converter.ts
+++ b/packages/zod/src/converter.ts
@@ -610,7 +610,7 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
 
         const [required, json] = this.convert(schema_._def.innerType, options, lazyDepth, false, false, structureDepth)
 
-        return [required, { anyOf: [{ type: 'null' }, json] }]
+        return [required, { anyOf: [json, { type: 'null' }] }]
       }
     }
 


### PR DESCRIPTION
Currently, the Zod converter transforms nullable types into schemas in the order of [null, json]. Because null appears as the first value in the array, UIs like Swagger or Scalar display null as the example value.
```json
{
    "nullableProperty": null
}
```


Although it is possible to customize the example using oz.openapi, I believe it is more reasonable to show a non-null default value as the example.
```json
{
    "nullableProperty": "non-null example"
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the order of types in nullable schemas to prioritize the main type before null.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->