### PR TITLE
docs: improve "Router to Contract"

### DIFF
--- a/apps/content/docs/contract-first/router-to-contract.md
+++ b/apps/content/docs/contract-first/router-to-contract.md
@@ -49,3 +49,14 @@ However, if you're deriving the contract from a [router](/docs/router), importin
       url: 'http://localhost:3000/api',
     })
     ```
+    
+    This usage doesn't make the client type-safe, because `as any` bypass any typescript inference, so you can use `as typeof router` if you want better types
+
+    ```ts
+    import contract from './contract.json' // [!code highlight]
+    import type { Router } from '../server/router' // Be sure to use "import type" and not "import" here
+
+    const link = new OpenAPILink(contract as Router, {
+      url: 'http://localhost:3000/api',
+    })
+    ```

--- a/apps/content/docs/contract-first/router-to-contract.md
+++ b/apps/content/docs/contract-first/router-to-contract.md
@@ -45,18 +45,11 @@ However, if you're deriving the contract from a [router](/docs/router), importin
     ```ts
     import contract from './contract.json' // [!code highlight]
 
-    const link = new OpenAPILink(contract as any, {
+    const link = new OpenAPILink(contract as typeof router, {
       url: 'http://localhost:3000/api',
     })
     ```
-    
-This usage doesn't make the client type-safe, because `as any` bypasses TypeScript's type inference. To correctly type the client, cast the imported contract to the type of your server-side router, as shown in the example below.
 
-    ```ts
-    import contract from './contract.json' // [!code highlight]
-    import type { Router } from '../server/router' // Be sure to use "import type" and not "import" here
-
-    const link = new OpenAPILink(contract as Router, {
-      url: 'http://localhost:3000/api',
-    })
-    ```
+    ::: warning
+    Cast `contract` to `typeof router` to ensure type safety, since standard schema types cannot be serialized to JSON so we must manually cast them.
+    :::

--- a/apps/content/docs/contract-first/router-to-contract.md
+++ b/apps/content/docs/contract-first/router-to-contract.md
@@ -50,7 +50,7 @@ However, if you're deriving the contract from a [router](/docs/router), importin
     })
     ```
     
-    This usage doesn't make the client type-safe, because `as any` bypass any typescript inference, so you can use `as typeof router` if you want better types
+This usage doesn't make the client type-safe, because `as any` bypasses TypeScript's type inference. To correctly type the client, cast the imported contract to the type of your server-side router, as shown in the example below.
 
     ```ts
     import contract from './contract.json' // [!code highlight]


### PR DESCRIPTION
I haven't tested it.  
Only written the result of this Github Discussion https://github.com/unnoq/orpc/discussions/696

Closes: https://github.com/unnoq/orpc/issues/732

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved guidance on TypeScript typing for imported contract JSON, including a safer example that preserves type inference and type safety when using contracts on the client side.  
  * Added a warning note explaining the necessity of manual casting due to JSON serialization limitations of standard schema types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->