### PR TITLE
feat(zod): support zod meta `title`  in generated JSON schema

### DIFF
--- a/packages/zod/src/zod4/converter.meta.test.ts
+++ b/packages/zod/src/zod4/converter.meta.test.ts
@@ -7,6 +7,7 @@ import {
 } from './registries'
 
 const customSchema1 = z.string().meta({
+  title: 'Custom String Schema',
   description: 'description',
   examples: ['a', 'b'],
 })
@@ -45,11 +46,20 @@ JSON_SCHEMA_OUTPUT_REGISTRY.add(customSchema3, {
   examples: ['1'],
 })
 
+const customSchemaWithTitleOnly = z.string().meta({
+  title: 'Title Only Schema',
+})
+
+const unionSchema = z.union([
+  z.string().meta({ title: 'String Option' }),
+  z.number().meta({ title: 'Number Option' }),
+])
+
 testSchemaConverter([
   {
     name: 'customSchema1',
     schema: customSchema1,
-    input: [true, { type: 'string', description: 'description', examples: ['a', 'b'] }],
+    input: [true, { type: 'string', title: 'Custom String Schema', description: 'description', examples: ['a', 'b'] }],
   },
   {
     name: 'customSchema1_unsupported_examples',
@@ -92,5 +102,20 @@ testSchemaConverter([
     name: 'string.readonly()',
     schema: z.string().readonly(),
     input: [true, { type: 'string', readOnly: true }],
+  },
+  {
+    name: 'customSchemaWithTitleOnly',
+    schema: customSchemaWithTitleOnly,
+    input: [true, { type: 'string', title: 'Title Only Schema' }],
+  },
+  {
+    name: 'unionSchema',
+    schema: unionSchema,
+    input: [true, {
+      anyOf: [
+        { type: 'string', title: 'String Option' },
+        { type: 'number', title: 'Number Option' },
+      ],
+    }],
   },
 ])

--- a/packages/zod/src/zod4/converter.ts
+++ b/packages/zod/src/zod4/converter.ts
@@ -581,6 +581,7 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
 
     if (global) {
       return {
+        title: global.title,
         description: global.description,
         examples: Array.isArray(global.examples) ? global.examples : undefined,
       }


### PR DESCRIPTION
## Summary
- Add support for `title` field in zod4 converter's global registry handling
- Enhance test coverage for title field functionality including union examples

**Explanation why it's useful:**
When using unions in array, it's helpful for openapi UIs to display the title of possible objects in array

before: 
<img width="342" height="214" alt="Screenshot 2025-07-15 at 16 02 57" src="https://github.com/user-attachments/assets/bfa1a9d1-faac-47c0-9cda-14df250caeb5" />

after:
<img width="394" height="216" alt="Screenshot 2025-07-15 at 16 05 27" src="https://github.com/user-attachments/assets/0f822823-f99b-495b-ba63-0bbd482778f6" />

I plan to submit one more PR with better handling for discriminated unions, but it should be good enough for start
