### PR TITLE
fix: use server-only package in next playground

### DIFF
--- a/playgrounds/next/package.json
+++ b/playgrounds/next/package.json
@@ -9,6 +9,9 @@
     "lint": "next lint",
     "type:check": "tsc --noEmit"
   },
+  "dependencies": {
+    "server-only": "^0.0.1"
+  },
   "devDependencies": {
     "@orpc/client": "next",
     "@orpc/json-schema": "next",

--- a/playgrounds/next/src/lib/orpc.server.ts
+++ b/playgrounds/next/src/lib/orpc.server.ts
@@ -1,4 +1,4 @@
-'server only'
+import 'server-only'
 
 import { router } from '@/router'
 import { createRouterClient } from '@orpc/server'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1122,6 +1122,10 @@ importers:
         version: 4.0.5
 
   playgrounds/next:
+    dependencies:
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
     devDependencies:
       '@orpc/client':
         specifier: next
@@ -10842,6 +10846,9 @@ packages:
   serve-static@2.2.0:
     resolution: {integrity: sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==}
     engines: {node: '>= 18'}
+
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
   set-cookie-parser@2.7.1:
     resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
@@ -23997,6 +24004,8 @@ snapshots:
       send: 1.2.0
     transitivePeerDependencies:
       - supports-color
+
+  server-only@0.0.1: {}
 
   set-cookie-parser@2.7.1: {}
 


### PR DESCRIPTION
In the next.js playground there is a `'server only'` directive.

According to the [docs](https://nextjs.org/docs/app/getting-started/server-and-client-components#preventing-environment-poisoning) `server-only` has to be used as a package, not a directive.

This PR fixes this issue.