### PR TITLE
docs: Update TanStack Query Integration docs to handle query key serialization of RPC data types

### DIFF
--- a/apps/content/docs/integrations/tanstack-query.md
+++ b/apps/content/docs/integrations/tanstack-query.md
@@ -335,6 +335,10 @@ const serializer = new StandardRPCJsonSerializer({
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
+      queryKeyHashFn(queryKey) {
+        const [json, meta] = serializer.serialize(queryKey)
+        return JSON.stringify({ json, meta })
+      },
       staleTime: 60 * 1000, // > 0 to prevent immediate refetching on mount
     },
     dehydrate: {
@@ -376,6 +380,10 @@ export function createQueryClient() {
   return new QueryClient({
     defaultOptions: {
       queries: {
+        queryKeyHashFn(queryKey) {
+          const [json, meta] = serializer.serialize(queryKey)
+          return JSON.stringify({ json, meta })
+        },
         staleTime: 60 * 1000, // > 0 to prevent immediate refetching on mount
       },
       dehydrate: {


### PR DESCRIPTION
Add custom queryKeyHashFn to handle serialization of RPC data types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated TanStack Query integration guide to show how to configure a custom key hashing option.
  * Added examples for both direct client setup and helper-based initialization for consistent behavior.
  * Improved instructions on where to place the option and clarified expected outcomes.
  * No runtime changes; examples refined for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->