### PR TITLE
feat(server): implement automatic error map merging for middleware

### DIFF
--- a/packages/server/src/builder.test.ts
+++ b/packages/server/src/builder.test.ts
@@ -130,7 +130,7 @@ describe('builder', () => {
 
     expect(applied).toBe(decorateMiddlewareSpy.mock.results[0]?.value)
     expect(decorateMiddlewareSpy).toBeCalledTimes(1)
-    expect(decorateMiddlewareSpy).toBeCalledWith(mid)
+    expect(decorateMiddlewareSpy).toBeCalledWith(mid, def.errorMap)
   })
 
   it('.errors', () => {

--- a/packages/server/src/middleware-decorated.ts
+++ b/packages/server/src/middleware-decorated.ts
@@ -1,4 +1,4 @@
-import type { Meta } from '@orpc/contract'
+import type { ErrorMap, Meta } from '@orpc/contract'
 import type { IntersectPick } from '@orpc/shared'
 import type { Context, MergedCurrentContext, MergedInitialContext } from './context'
 import type { ORPCErrorConstructorMap } from './error'
@@ -12,6 +12,11 @@ export interface DecoratedMiddleware<
   TErrorConstructorMap extends ORPCErrorConstructorMap<any>,
   TMeta extends Meta,
 > extends Middleware<TInContext, TOutContext, TInput, TOutput, TErrorConstructorMap, TMeta> {
+  /**
+   * Error map associated with this middleware (if any)
+   * @internal
+   */
+  errorMap?: ErrorMap
   /**
    * Change the expected input type by providing a map function.
    */
@@ -78,6 +83,8 @@ export interface DecoratedMiddleware<
   >
 }
 
+export type AnyDecoratedMiddleware = DecoratedMiddleware<any, any, any, any, any, any>
+
 export function decorateMiddleware<
   TInContext extends Context,
   TOutContext extends Context,
@@ -87,21 +94,33 @@ export function decorateMiddleware<
   TMeta extends Meta,
 >(
   middleware: Middleware<TInContext, TOutContext, TInput, TOutput, TErrorConstructorMap, TMeta>,
+  errorMap?: ErrorMap,
 ): DecoratedMiddleware<TInContext, TOutContext, TInput, TOutput, TErrorConstructorMap, TMeta> {
   const decorated = ((...args) => middleware(...args)) as DecoratedMiddleware<TInContext, TOutContext, TInput, TOutput, TErrorConstructorMap, TMeta>
+
+  // Attach error map if provided
+  if (errorMap) {
+    decorated.errorMap = errorMap
+  }
 
   decorated.mapInput = (mapInput) => {
     const mapped = decorateMiddleware(
       (options, input, ...rest) => middleware(options as any, mapInput(input as any), ...rest as [any]),
+      decorated.errorMap, // Preserve error map
     )
 
     return mapped as any
   }
 
-  decorated.concat = (concatMiddleware: AnyMiddleware, mapInput?: MapInputMiddleware<any, any>) => {
+  decorated.concat = (concatMiddleware: AnyMiddleware | AnyDecoratedMiddleware, mapInput?: MapInputMiddleware<any, any>) => {
     const mapped = mapInput
       ? decorateMiddleware(concatMiddleware).mapInput(mapInput)
       : concatMiddleware
+
+    const combinedErrorMap = {
+      ...decorated.errorMap,
+      ...('errorMap' in concatMiddleware ? concatMiddleware.errorMap : undefined),
+    }
 
     const concatted = decorateMiddleware((options, input, output, ...rest) => {
       const merged = middleware({
@@ -114,7 +133,7 @@ export function decorateMiddleware<
       } as any, input as any, output as any, ...rest)
 
       return merged
-    })
+    }, combinedErrorMap)
 
     return concatted as any
   }

--- a/packages/server/tests/error-middleware-pattern.test.ts
+++ b/packages/server/tests/error-middleware-pattern.test.ts
@@ -1,0 +1,80 @@
+import { createSafeClient } from '@orpc/client'
+import { createRouterClient, os } from '../src'
+
+describe('error middleware patterns', () => {
+  it('should have defined=true when using original supported pattern (same base for middleware and procedure)', async () => {
+    // ✅ CORRECT: Define errors on base, use same base for both middleware and procedure
+    const base = os.errors({
+      UNAUTHORIZED: {},
+    })
+
+    const middleware = base.middleware(async ({ next, context, errors }) => {
+      throw errors.UNAUTHORIZED()
+    })
+
+    const router = base.use(middleware).handler(async () => {})
+
+    const client = createSafeClient(createRouterClient(router))
+    const [error,, isDefined] = await client()
+
+    // Should have defined=true because error was thrown from defined error map
+    expect((error as any).defined).toBe(true)
+    expect(isDefined).toBe(true)
+    expect((error as any).code).toBe('UNAUTHORIZED')
+  })
+
+  it('should have defined=true with automatic error map merging (new behavior)', async () => {
+    // ✅ NEW BEHAVIOR: Middleware error maps are automatically merged
+    const middleware = os.errors({
+      UNAUTHORIZED: {},
+    }).middleware(async ({ next, context, errors }) => {
+      throw errors.UNAUTHORIZED()
+    })
+
+    // Using base os (no errors) but middleware error map should be automatically merged
+    const router = os.use(middleware).handler(async () => {})
+
+    const client = createSafeClient(createRouterClient(router))
+    const [error,, isDefined] = await client()
+
+    // Should now have defined=true because middleware error map gets merged automatically
+    expect((error as any).defined).toBe(true)
+    expect(isDefined).toBe(true)
+    expect((error as any).code).toBe('UNAUTHORIZED')
+    // Verify the error map was merged
+    expect(router['~orpc'].errorMap).toHaveProperty('UNAUTHORIZED')
+  })
+
+  it('should merge errors from different sources correctly', async () => {
+    const middleware = os.errors({
+      UNAUTHORIZED: {},
+    }).middleware(async ({ next, context, errors }) => {
+      // Don't throw, just continue to test error map merging
+      return next({ context })
+    })
+    const router = os
+      .use(middleware)
+      .errors({ NOT_FOUND: {} })
+      .handler(async ({ errors }) => {
+        // Should have access to both UNAUTHORIZED and NOT_FOUND
+        expect('UNAUTHORIZED' in errors).toBe(true)
+        expect('NOT_FOUND' in errors).toBe(true)
+
+        // @ts-expect-error TODO: Currently, errors defined in middleware is not inferred into the procedure
+        const unauthorizedError = errors.UNAUTHORIZED()
+        const notFoundError = errors.NOT_FOUND()
+
+        expect(unauthorizedError.defined).toBe(true)
+        expect(notFoundError.defined).toBe(true)
+
+        throw notFoundError
+      })
+
+    const client = createSafeClient(createRouterClient(router))
+    const [error,, isDefined] = await client()
+
+    expect((error as any).defined).toBe(true)
+    expect(isDefined).toBe(true)
+    expect((error as any).code).toBe('NOT_FOUND')
+  })
+})


### PR DESCRIPTION
## Changes of the PR

- Add errorMap property to DecoratedMiddleware interface
- Automatically merge middleware error maps when using .use() method
- Update Builder and DecoratedProcedure to handle error map merging
- Add comprehensive tests for error middleware patterns
- Maintain backward compatibility with existing middleware usage

This change ensures that errors thrown from middleware are properly recognized as "defined" errors, fixing the error handling issue where middleware errors were not being properly typed or handled.

---

I want https://github.com/unnoq/orpc/discussions/757#discussion-8568819 to be implement so I give it a try.

## A simple snippet I used to test it:

```typescript
import { createSafeClient, onError } from "@orpc/client";
import { createRouterClient, os } from "@orpc/server";

const middleware = os
  .errors({
    UNAUTHORIZED: {},
  })
  .middleware(async ({ next, context, errors }, input) => {
    throw errors.UNAUTHORIZED();
  })

const router = os.use(middleware).handler(async () => {});

const client = createSafeClient(
  createRouterClient(router, {
    interceptors: [
      onError((error) =>
        console.dir(error, {
          depth: Infinity,
          colors: true,
        })
      ),
    ],
  })
);

client();
```

It logs:

```json
{ [Error: Unauthorized] defined: false, code: 'UNAUTHORIZED', status: 401, data: undefined }
```

This PR make `defined` to be `true`

## Soem notes

I found that type of middleware already know errors but not really use it at the time. I tried not to touch too much not-directly-related-code and I think the best spot is to store errors in DecoratedMiddleware. As the author want middleware to be clean. And thank to this, the implementation is not affecting too much logical structure.

_packages/server/tests/error-middleware-pattern.test.ts_ is a simple test to state out how thing should work before and after.

Because the test strictly want inline middleware to be as is

https://github.com/unnoq/orpc/blob/7f288fbb2586863d0cdd3acdc27b5e2d727f154e/packages/server/src/builder.test.ts#L150-L160

It took me some time to make the code work and be pretty. I introduce a `AnyDecoratedMiddleware` to help with it.

https://github.com/QzCurious/orpc/blob/d558620109300ba41f04984fe1713b9184d4ea7f/packages/server/src/builder.ts#L192-L212

