### PR TITLE
feat(dei): enforce JWT expiry & revocation; add kickIfInvalid; tests

### DIFF
--- a/packages/durable-event-iterator/src/durable-object/handler.test.ts
+++ b/packages/durable-event-iterator/src/durable-object/handler.test.ts
@@ -7,7 +7,7 @@ import { durableEventIteratorRouter } from './handler'
 import { DurableEventIteratorObjectWebsocketManager } from './websocket-manager'
 
 describe('durableEventIteratorRouter', async () => {
-  const date = 144434837
+  const date = Date.now()
 
   const tokenPayload = {
     att: { some: 'attachment' },

--- a/packages/durable-event-iterator/src/durable-object/websocket-manager.test.ts
+++ b/packages/durable-event-iterator/src/durable-object/websocket-manager.test.ts
@@ -5,6 +5,7 @@ import { DURABLE_EVENT_ITERATOR_HIBERNATION_ID_KEY, DURABLE_EVENT_ITERATOR_TOKEN
 import { DurableEventIteratorObjectEventStorage } from './event-storage'
 import { DurableEventIteratorObjectWebsocketManager } from './websocket-manager'
 
+vi.mock('@orpc/server/hibernation', { spy: true })
 const encodeHibernationRPCEventSpy = vi.spyOn(Hibernation, 'encodeHibernationRPCEvent')
 
 beforeEach(() => {
@@ -20,7 +21,8 @@ describe('durableEventIteratorObjectWebsocketManager', () => {
       ctx,
       storage,
     )
-
+    const tokIat = Math.floor(Date.now() / 1000)
+    const tokExpiration = tokIat + 3600
     /**
      * Usually set hibernation happen after token payload, but this for test coverage
      */
@@ -34,8 +36,8 @@ describe('durableEventIteratorObjectWebsocketManager', () => {
       [DURABLE_EVENT_ITERATOR_TOKEN_PAYLOAD_KEY]: {
         att: { att: true },
         chn: 'test-channel',
-        exp: 1923456789,
-        iat: 1923456780,
+        exp: tokExpiration,
+        iat: tokIat,
         rpc: ['test'],
       },
     })
@@ -54,8 +56,8 @@ describe('durableEventIteratorObjectWebsocketManager', () => {
       [DURABLE_EVENT_ITERATOR_TOKEN_PAYLOAD_KEY]: {
         att: { att: true },
         chn: 'test-channel',
-        exp: 1923456789,
-        iat: 1923456780,
+        exp: tokExpiration,
+        iat: tokIat,
         rpc: ['test'],
       },
       [DURABLE_EVENT_ITERATOR_HIBERNATION_ID_KEY]: '123',
@@ -71,7 +73,8 @@ describe('durableEventIteratorObjectWebsocketManager', () => {
     const options = {
       customJsonSerializers: [],
     }
-
+    const tokIat = Math.floor(Date.now() / 1000)
+    const tokExpiration = tokIat + 3600
     const manager = new DurableEventIteratorObjectWebsocketManager<any, any, any>(
       ctx,
       storage,
@@ -85,8 +88,8 @@ describe('durableEventIteratorObjectWebsocketManager', () => {
       [DURABLE_EVENT_ITERATOR_TOKEN_PAYLOAD_KEY]: {
         att: { att: true },
         chn: 'test-channel',
-        exp: 1923456789,
-        iat: 1923456780,
+        exp: tokExpiration,
+        iat: tokIat,
         rpc: ['test'],
       },
       [DURABLE_EVENT_ITERATOR_HIBERNATION_ID_KEY]: '123',
@@ -96,16 +99,15 @@ describe('durableEventIteratorObjectWebsocketManager', () => {
       [DURABLE_EVENT_ITERATOR_TOKEN_PAYLOAD_KEY]: {
         att: { att: true },
         chn: 'test-channel',
-        exp: 1923456789,
-        iat: 1923456780,
+        exp: tokExpiration,
+        iat: tokIat,
         rpc: ['test'],
       },
     })
 
     const wss = [websocket, websocket2]
-    manager.publishEvent(wss, { test: 'event1' })
-    manager.publishEvent(wss, { test: 'event2' })
-
+    await manager.publishEvent(wss, { test: 'event1' })
+    await manager.publishEvent(wss, { test: 'event2' })
     expect(encodeHibernationRPCEventSpy).toHaveBeenCalledTimes(2)
     expect(encodeHibernationRPCEventSpy).toHaveBeenNthCalledWith(1, '123', withEventMeta({ test: 'event1' }, { id: '1' }), options)
     expect(encodeHibernationRPCEventSpy).toHaveBeenNthCalledWith(2, '123', withEventMeta({ test: 'event2' }, { id: '2' }), options)
@@ -124,6 +126,8 @@ describe('durableEventIteratorObjectWebsocketManager', () => {
     const ctx = createDurableObjectState()
     const storage = new DurableEventIteratorObjectEventStorage(ctx)
     const websocket = createCloudflareWebsocket()
+    const tokIat = Math.floor(Date.now() / 1000)
+
     const options = {
       customJsonSerializers: [],
     }
@@ -133,12 +137,21 @@ describe('durableEventIteratorObjectWebsocketManager', () => {
       storage,
       options,
     )
-
+    manager.serializeInternalAttachment(websocket, {
+      [DURABLE_EVENT_ITERATOR_TOKEN_PAYLOAD_KEY]: {
+        att: { att: true },
+        chn: 'test-channel',
+        exp: tokIat + 3600,
+        iat: tokIat,
+        rpc: ['test'],
+      },
+      [DURABLE_EVENT_ITERATOR_HIBERNATION_ID_KEY]: '123',
+    })
     storage.storeEvent({ test: 'event1' })
     storage.storeEvent({ test: 'event2' })
     storage.storeEvent({ test: 'event3' })
 
-    manager.sendEventsAfter(websocket, '123', '1')
+    await manager.sendEventsAfter(websocket, '123', '1')
 
     expect(encodeHibernationRPCEventSpy).toHaveBeenCalledTimes(2)
     expect(encodeHibernationRPCEventSpy).toHaveBeenNthCalledWith(1, '123', withEventMeta({ test: 'event2' }, { id: '2' }), options)
@@ -148,4 +161,111 @@ describe('durableEventIteratorObjectWebsocketManager', () => {
     expect(websocket.send).toHaveBeenNthCalledWith(1, encodeHibernationRPCEventSpy.mock.results[0]!.value)
     expect(websocket.send).toHaveBeenNthCalledWith(2, encodeHibernationRPCEventSpy.mock.results[1]!.value)
   })
+})
+
+it('publishEvent closes sockets with expired tokens and skips sending', async () => {
+  vi.useFakeTimers()
+  const fixedNow = new Date('2025-01-01T00:00:00Z')
+  vi.setSystemTime(fixedNow)
+  const nowSec = Math.floor(fixedNow.getTime() / 1000)
+
+  const ctx = createDurableObjectState()
+  const storage = new DurableEventIteratorObjectEventStorage(ctx)
+  const websocketValid = createCloudflareWebsocket()
+  const websocketExpired = createCloudflareWebsocket()
+  const options = { customJsonSerializers: [] }
+
+  // ensure `close` is a mock so we can assert on it
+  ;(websocketValid as any).close = vi.fn()
+  ;(websocketExpired as any).close = vi.fn()
+
+  const manager = new DurableEventIteratorObjectWebsocketManager<any, any, any>(
+    ctx,
+    storage,
+    options,
+  )
+
+  // valid token
+  manager.serializeInternalAttachment(websocketValid, {
+    [DURABLE_EVENT_ITERATOR_TOKEN_PAYLOAD_KEY]: {
+      att: { att: true },
+      chn: 'test-channel',
+      exp: nowSec + 60,
+      iat: nowSec - 10,
+      rpc: ['test'],
+    },
+    [DURABLE_EVENT_ITERATOR_HIBERNATION_ID_KEY]: 'valid-hib-id',
+  })
+
+  // expired token (now >= exp)
+  manager.serializeInternalAttachment(websocketExpired, {
+    [DURABLE_EVENT_ITERATOR_TOKEN_PAYLOAD_KEY]: {
+      att: { att: true },
+      chn: 'test-channel',
+      exp: nowSec - 1,
+      iat: nowSec - 10,
+      rpc: ['test'],
+    },
+    [DURABLE_EVENT_ITERATOR_HIBERNATION_ID_KEY]: 'expired-hib-id',
+  })
+
+  await manager.publishEvent([websocketValid, websocketExpired], { test: 'event1' })
+
+  // valid ws receives one event
+  expect(encodeHibernationRPCEventSpy).toHaveBeenCalledTimes(1)
+  expect(websocketValid.send).toHaveBeenCalledTimes(1)
+  expect((websocketValid as any).close).not.toHaveBeenCalled()
+
+  // expired ws is closed with the "expired" code and doesn't send
+  expect((websocketExpired as any).close).toHaveBeenCalledTimes(1)
+  expect((websocketExpired as any).close).toHaveBeenCalledWith(4001, 'token expired')
+  expect(websocketExpired.send).not.toHaveBeenCalled()
+
+  vi.useRealTimers()
+})
+
+it('sendEventsAfter closes and skips sending when token is expired', async () => {
+  vi.useFakeTimers()
+  const fixedNow = new Date('2025-01-01T00:00:00Z')
+  vi.setSystemTime(fixedNow)
+  const nowSec = Math.floor(fixedNow.getTime() / 1000)
+
+  const ctx = createDurableObjectState()
+  const storage = new DurableEventIteratorObjectEventStorage(ctx)
+  const websocket = createCloudflareWebsocket()
+  const options = { customJsonSerializers: [] }
+
+  // ensure `close` is a mock so we can assert on it
+  ;(websocket as any).close = vi.fn()
+
+  const manager = new DurableEventIteratorObjectWebsocketManager<any, any, any>(
+    ctx,
+    storage,
+    options,
+  )
+
+  manager.serializeInternalAttachment(websocket, {
+    [DURABLE_EVENT_ITERATOR_TOKEN_PAYLOAD_KEY]: {
+      att: { att: true },
+      chn: 'test-channel',
+      exp: nowSec - 1, // expired
+      iat: nowSec - 10,
+      rpc: ['test'],
+    },
+    [DURABLE_EVENT_ITERATOR_HIBERNATION_ID_KEY]: 'hib-123',
+  })
+
+  // seed some events (should not be sent)
+  storage.storeEvent({ test: 'event1' })
+  storage.storeEvent({ test: 'event2' })
+
+  await manager.sendEventsAfter(websocket, 'hib-123', '0')
+
+  // no encode/sends happen, socket is closed for expiry
+  expect(encodeHibernationRPCEventSpy).not.toHaveBeenCalled()
+  expect(websocket.send).not.toHaveBeenCalled()
+  expect((websocket as any).close).toHaveBeenCalledTimes(1)
+  expect((websocket as any).close).toHaveBeenCalledWith(4001, 'token expired')
+
+  vi.useRealTimers()
 })


### PR DESCRIPTION
Ensures JWT is checked on send and on inbound RPC. Adds optional revocation hook, closes WS with 4001/4003, updates router to guard .call via kickIfInvalid, and adds expiry tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically detects and disconnects expired or revoked WebSocket sessions with dedicated close codes.
  - Adds a configurable hook to decide when a WebSocket should be disconnected.
  - Skips sending events to invalid sessions while continuing delivery to valid clients.
- Bug Fixes
  - Prevents events from being sent to expired sessions.
- Refactor
  - Converted call routing and event delivery to async for improved reliability.
- Tests
  - Expanded coverage for token expiry scenarios with time-based assertions and async flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->